### PR TITLE
Release v1.2.0

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,66 @@
+# Publishes a preview of every pull request to GitHub Pages so changes can be
+# reviewed from any device (phone included) before being merged.
+#
+#   Preview URL: https://thiagocolen.github.io/pr-preview/pr-<number>/
+#
+# The preview is removed automatically when the PR is closed or merged.
+#
+# Notes:
+#   - The local SQLite database (src/data/posts.db) is never committed, so CI
+#     rebuilds one from src/data/schema.sql and seeds it with the published
+#     posts exported to src/data/published-posts.json (npm run db:export).
+#   - Previews are served from a subdirectory, so the build needs PATH_PREFIX
+#     plus --prefix-paths. Production builds are unaffected.
+#   - Previews live alongside production content on the gh-pages branch and are
+#     publicly reachable, like the rest of the site.
+
+name: PR Preview
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+
+concurrency:
+  group: pr-preview-${{ github.event.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        if: github.event.action != 'closed'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        if: github.event.action != 'closed'
+        run: npm ci
+
+      - name: Seed posts database
+        if: github.event.action != 'closed'
+        run: npm run db:seed
+
+      - name: Build site
+        if: github.event.action != 'closed'
+        env:
+          # No leading slash: Gatsby's config validation rejects one and adds it
+          # itself (see the pathPrefix note in gatsby-config.js).
+          PATH_PREFIX: pr-preview/pr-${{ github.event.number }}
+        run: npm run build -- --prefix-paths
+
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: public/
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          action: auto

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -26,6 +26,7 @@ concurrency:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   preview:

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -43,7 +43,10 @@ jobs:
 
       - name: Install dependencies
         if: github.event.action != 'closed'
-        run: npm ci
+        # --legacy-peer-deps: gatsby-plugin-mdx-embed@0.0.20-alpha declares a
+        # peer on react@16.x while the project is on react@17; npm's default
+        # (strict) resolver rejects that even though it works fine in practice.
+        run: npm ci --legacy-peer-deps
 
       - name: Seed posts database
         if: github.event.action != 'closed'

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - 🛠️ [Technologies Involved](#-technologies-involved)
 - 📡 [DEV.to Integration](#-devto-integration)
 - ⚙️ [How the Site Works](#-how-the-site-works)
+- 👀 [PR Previews](#-pr-previews)
 - 🧠 [Development Philosophy](#-development-philosophy)
 
 ---
@@ -58,6 +59,32 @@ graph TD
 2. **Data Fetching:** It retrieves all published articles and their full content. 📦
 3. **Page Generation:** Gatsby dynamically creates individual post pages for each article at `/blog/post/[slug]/` and updates the article lists on the home and blog pages. 📄
 4. **Deployment:** Once the build is complete, a static version of the site is deployed, ensuring high performance and security. 🛡️
+
+## 👀 PR Previews
+
+Every pull request is built and published to a preview URL, so changes can be reviewed from any device before being merged:
+
+```
+https://thiagocolen.github.io/pr-preview/pr-<number>/
+```
+
+The preview is created when the PR opens, refreshed on every push, and deleted when the PR is closed or merged.
+
+**⚠️ Keeping previews in sync with your posts:** the local database (`src/data/posts.db`) is the source of true and is never committed, so CI cannot read it. Preview builds instead rebuild a database from `src/data/schema.sql` and seed it from `src/data/published-posts.json`.
+
+That means **after publishing a new post, re-export and commit the JSON** — otherwise previews will show stale content:
+
+```bash
+npm run db:export   # writes src/data/published-posts.json (published posts only)
+```
+
+Only `published` posts are exported; unpublished drafts stay local and out of git.
+
+| Command | Purpose |
+| :--- | :--- |
+| `npm run db:init` | Create the database from `schema.sql` (idempotent) |
+| `npm run db:export` | Export published posts to `published-posts.json` |
+| `npm run db:seed` | Init + seed from the JSON — what CI runs |
 
 ## 🧠 Development Philosophy
 

--- a/develop-tools/add-posts-from-json.js
+++ b/develop-tools/add-posts-from-json.js
@@ -21,7 +21,11 @@ const Database = require("better-sqlite3");
 const path = require("path");
 const fs = require("fs");
 
-const DB_PATH = path.resolve(__dirname, "../src/data/posts.db");
+// POSTS_DB_PATH lets CI (and tests) target a database outside the default
+// location without disturbing the local source-of-true database.
+const DB_PATH = process.env.POSTS_DB_PATH
+  ? path.resolve(process.cwd(), process.env.POSTS_DB_PATH)
+  : path.resolve(__dirname, "../src/data/posts.db");
 const VALID_STATUSES = ["published", "unpublished"];
 const SLUG_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 

--- a/develop-tools/add-posts-from-json.js
+++ b/develop-tools/add-posts-from-json.js
@@ -1,0 +1,147 @@
+// -----------------------------------------------------
+// Add posts to the local SQLite database from a JSON file.
+//
+// Usage:
+//   node develop-tools/add-posts-from-json.js <path-to-json>
+//   npm run db:add-posts -- <path-to-json>
+//
+// The JSON file may contain a single post object or an array of
+// post objects — see develop-tools/schema/posts.schema.json and
+// develop-tools/schema/post.example.json.
+//
+// Rules (mirrors src/data/schema.sql's lifecycle comment):
+//   - Matching is done by "slug".
+//   - Existing posts already marked 'published' are read-only
+//     and are skipped rather than overwritten.
+//   - Existing 'unpublished' posts are updated in place.
+//   - New slugs are inserted (default status: 'unpublished').
+// -----------------------------------------------------
+
+const Database = require("better-sqlite3");
+const path = require("path");
+const fs = require("fs");
+
+const DB_PATH = path.resolve(__dirname, "../src/data/posts.db");
+const VALID_STATUSES = ["published", "unpublished"];
+const SLUG_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+const loadPostsFromFile = (filePath) => {
+  const resolved = path.resolve(process.cwd(), filePath);
+  if (!fs.existsSync(resolved)) {
+    throw new Error(`File not found: ${resolved}`);
+  }
+  const parsed = JSON.parse(fs.readFileSync(resolved, "utf-8"));
+  return Array.isArray(parsed) ? parsed : [parsed];
+};
+
+const validatePost = (post, index) => {
+  const errors = [];
+
+  if (!post.title || typeof post.title !== "string") {
+    errors.push('missing or invalid "title"');
+  }
+  if (!post.slug || typeof post.slug !== "string" || !SLUG_PATTERN.test(post.slug)) {
+    errors.push('missing or invalid "slug" (expected lowercase, hyphen-separated)');
+  }
+  if (post.status !== undefined && !VALID_STATUSES.includes(post.status)) {
+    errors.push(`invalid "status" (must be one of: ${VALID_STATUSES.join(", ")})`);
+  }
+  if (post.tags !== undefined && !Array.isArray(post.tags)) {
+    errors.push('"tags" must be an array of strings');
+  }
+
+  if (errors.length > 0) {
+    const label = post.slug || post.title || `#${index + 1}`;
+    throw new Error(`Post "${label}" is invalid: ${errors.join("; ")}`);
+  }
+};
+
+const prepareStatements = (db) => ({
+  findBySlug: db.prepare(`SELECT id, status FROM articles WHERE slug = @slug`),
+  insertArticle: db.prepare(`
+    INSERT INTO articles (title, description, body_html, slug, published_at, cover_image, status)
+    VALUES (@title, @description, @body_html, @slug, @published_at, @cover_image, @status)
+  `),
+  updateArticle: db.prepare(`
+    UPDATE articles
+    SET title = @title, description = @description, body_html = @body_html,
+        published_at = @published_at, cover_image = @cover_image, status = @status
+    WHERE id = @id
+  `),
+  deleteTagsForArticle: db.prepare(`DELETE FROM tags WHERE article_id = @article_id`),
+  insertTag: db.prepare(`INSERT INTO tags (article_id, name) VALUES (@article_id, @name)`),
+});
+
+const upsertPost = (statements, post) => {
+  const existing = statements.findBySlug.get({ slug: post.slug });
+
+  if (existing && existing.status === "published") {
+    console.log(`  ⊘ Skipped (published/read-only): "${post.title}"`);
+    return "skipped";
+  }
+
+  const values = {
+    title: post.title,
+    description: post.description ?? null,
+    body_html: post.body_html ?? null,
+    slug: post.slug,
+    published_at: post.published_at ?? null,
+    cover_image: post.cover_image ?? null,
+    status: post.status ?? "unpublished",
+  };
+
+  let articleId;
+  if (existing) {
+    statements.updateArticle.run({ ...values, id: existing.id });
+    articleId = existing.id;
+    console.log(`  ✓ Updated: "${post.title}"`);
+  } else {
+    const info = statements.insertArticle.run(values);
+    articleId = info.lastInsertRowid;
+    console.log(`  ✓ Added: "${post.title}"`);
+  }
+
+  statements.deleteTagsForArticle.run({ article_id: articleId });
+  for (const tag of post.tags ?? []) {
+    statements.insertTag.run({ article_id: articleId, name: tag });
+  }
+
+  return existing ? "updated" : "added";
+};
+
+const run = () => {
+  const filePath = process.argv[2];
+  if (!filePath) {
+    console.error("Usage: node develop-tools/add-posts-from-json.js <path-to-json>");
+    process.exit(1);
+  }
+
+  console.log(`\n📖 Reading posts from: ${filePath}\n`);
+  const posts = loadPostsFromFile(filePath);
+  posts.forEach(validatePost);
+
+  const db = new Database(DB_PATH);
+  db.pragma("foreign_keys = ON");
+  const statements = prepareStatements(db);
+
+  const summary = { added: 0, updated: 0, skipped: 0 };
+  const runAll = db.transaction((allPosts) => {
+    for (const post of allPosts) {
+      summary[upsertPost(statements, post)] += 1;
+    }
+  });
+  runAll(posts);
+
+  db.close();
+
+  console.log(
+    `\n✅ Done. Added: ${summary.added}, Updated: ${summary.updated}, Skipped: ${summary.skipped}\n`
+  );
+};
+
+try {
+  run();
+} catch (err) {
+  console.error("❌ Failed to add posts:", err.message);
+  process.exit(1);
+}

--- a/develop-tools/export-published-to-json.js
+++ b/develop-tools/export-published-to-json.js
@@ -1,0 +1,75 @@
+// -----------------------------------------------------
+// Export published posts from the local SQLite database to JSON.
+//
+// Usage:
+//   node develop-tools/export-published-to-json.js [output-path]
+//   npm run db:export
+//
+// The local database (src/data/posts.db) is the source of true and is
+// never committed. CI has no access to it, so PR preview builds are
+// seeded from the JSON file this script produces.
+//
+// Only 'published' posts are exported — the same filter the website
+// applies at build time (see gatsby-config.js). Unpublished drafts stay
+// local and out of git history.
+//
+// The output matches develop-tools/schema/posts.schema.json, so it can be
+// fed straight back into add-posts-from-json.js.
+// -----------------------------------------------------
+
+const Database = require("better-sqlite3");
+const path = require("path");
+const fs = require("fs");
+
+const DB_PATH = path.resolve(__dirname, "../src/data/posts.db");
+const DEFAULT_OUT = path.resolve(__dirname, "../src/data/published-posts.json");
+
+const run = () => {
+  const outPath = process.argv[2]
+    ? path.resolve(process.cwd(), process.argv[2])
+    : DEFAULT_OUT;
+
+  if (!fs.existsSync(DB_PATH)) {
+    throw new Error(
+      `Database not found: ${DB_PATH}\n` +
+        `   Run "npm run db:init" and import posts before exporting.`
+    );
+  }
+
+  const db = new Database(DB_PATH, { readonly: true });
+
+  const articles = db
+    .prepare(
+      `SELECT title, description, body_html, slug, published_at, cover_image, status
+       FROM articles
+       WHERE status = 'published'
+       ORDER BY published_at DESC`
+    )
+    .all();
+
+  const tagsFor = db.prepare(
+    `SELECT t.name
+     FROM tags t
+     JOIN articles a ON a.id = t.article_id
+     WHERE a.slug = @slug
+     ORDER BY t.name`
+  );
+
+  const posts = articles.map((article) => ({
+    ...article,
+    tags: tagsFor.all({ slug: article.slug }).map((row) => row.name),
+  }));
+
+  db.close();
+
+  fs.writeFileSync(outPath, `${JSON.stringify(posts, null, 2)}\n`, "utf-8");
+
+  console.log(`\n✅ Exported ${posts.length} published post(s) to:\n   ${outPath}\n`);
+};
+
+try {
+  run();
+} catch (err) {
+  console.error("❌ Failed to export posts:", err.message);
+  process.exit(1);
+}

--- a/develop-tools/init-db.js
+++ b/develop-tools/init-db.js
@@ -1,0 +1,47 @@
+// -----------------------------------------------------
+// Create the local SQLite database from src/data/schema.sql.
+//
+// Usage:
+//   node develop-tools/init-db.js
+//   npm run db:init
+//
+// Idempotent — schema.sql uses CREATE TABLE IF NOT EXISTS, so running
+// this against an existing database leaves its data untouched.
+//
+// Mainly used by CI: the PR preview workflow has no access to the local
+// database (it is never committed), so it builds one from this schema and
+// then seeds it from src/data/published-posts.json.
+// -----------------------------------------------------
+
+const Database = require("better-sqlite3");
+const path = require("path");
+const fs = require("fs");
+
+// POSTS_DB_PATH lets CI (and tests) target a database outside the default
+// location without disturbing the local source-of-true database.
+const DB_PATH = process.env.POSTS_DB_PATH
+  ? path.resolve(process.cwd(), process.env.POSTS_DB_PATH)
+  : path.resolve(__dirname, "../src/data/posts.db");
+const SCHEMA_PATH = path.resolve(__dirname, "../src/data/schema.sql");
+
+const run = () => {
+  if (!fs.existsSync(SCHEMA_PATH)) {
+    throw new Error(`Schema not found: ${SCHEMA_PATH}`);
+  }
+
+  fs.mkdirSync(path.dirname(DB_PATH), { recursive: true });
+
+  const db = new Database(DB_PATH);
+  db.pragma("foreign_keys = ON");
+  db.exec(fs.readFileSync(SCHEMA_PATH, "utf-8"));
+  db.close();
+
+  console.log(`\n✅ Database ready at:\n   ${DB_PATH}\n`);
+};
+
+try {
+  run();
+} catch (err) {
+  console.error("❌ Failed to initialise database:", err.message);
+  process.exit(1);
+}

--- a/develop-tools/schema/post.example.json
+++ b/develop-tools/schema/post.example.json
@@ -1,0 +1,10 @@
+{
+  "title": "Understanding Event Loops in Node.js",
+  "description": "A practical walkthrough of how the Node.js event loop schedules callbacks, timers, and I/O.",
+  "body_html": "<p>The event loop is the mechanism that lets Node.js perform non-blocking I/O despite JavaScript being single-threaded...</p>",
+  "slug": "understanding-event-loops-in-nodejs",
+  "published_at": "2026-07-15T12:00:00Z",
+  "cover_image": "https://example.com/images/event-loop-cover.png",
+  "status": "unpublished",
+  "tags": ["nodejs", "javascript", "event-loop"]
+}

--- a/develop-tools/schema/posts.schema.json
+++ b/develop-tools/schema/posts.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://thiagocolen.github.io/schemas/posts.schema.json",
+  "title": "Posts input file",
+  "description": "Schema for JSON files consumed by develop-tools/add-posts-from-json.js. Accepts either a single post object or an array of post objects.",
+  "oneOf": [
+    { "$ref": "#/$defs/post" },
+    { "type": "array", "items": { "$ref": "#/$defs/post" }, "minItems": 1 }
+  ],
+  "$defs": {
+    "post": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Post title."
+        },
+        "description": {
+          "type": ["string", "null"],
+          "description": "Short summary/excerpt shown in listings."
+        },
+        "body_html": {
+          "type": ["string", "null"],
+          "description": "Full post content, as HTML."
+        },
+        "slug": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+          "description": "URL-safe unique identifier, e.g. \"my-first-post\". Used to find existing posts for update."
+        },
+        "published_at": {
+          "type": ["string", "null"],
+          "format": "date-time",
+          "description": "ISO-8601 timestamp. Null/omitted for drafts."
+        },
+        "cover_image": {
+          "type": ["string", "null"],
+          "format": "uri",
+          "description": "URL of the cover image."
+        },
+        "status": {
+          "type": "string",
+          "enum": ["published", "unpublished"],
+          "default": "unpublished",
+          "description": "Posts marked 'published' become read-only — the script will refuse to update them."
+        },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "description": "List of tag names."
+        }
+      },
+      "required": ["title", "slug"]
+    }
+  }
+}

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,4 +1,17 @@
+// PR preview builds are served from a subdirectory of the site
+// (https://thiagocolen.github.io/pr-preview/pr-N/), so asset and link URLs
+// need that prefix. The PR preview workflow sets PATH_PREFIX and builds with
+// `gatsby build --prefix-paths`; production builds leave it empty and serve
+// from the domain root, where Gatsby ignores pathPrefix entirely.
+//
+// PATH_PREFIX must NOT start with a slash. Gatsby validates pathPrefix as a
+// relative-only URI and then prepends the leading slash itself, so a value
+// like "/pr-preview/pr-1" fails with 'must be a valid relative uri'. Pass
+// "pr-preview/pr-1" and Gatsby resolves it to "/pr-preview/pr-1".
+const pathPrefix = process.env.PATH_PREFIX || "";
+
 module.exports = {
+  pathPrefix,
   plugins: [
     "gatsby-plugin-postcss",
     {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "clean": "gatsby clean",
     "deploy": "gatsby build && gh-pages -d public",
     "db:migrate": "node develop-tools/migrate-devto-to-sqlite.js",
-    "db:add-status": "node develop-tools/add-status-column.js"
+    "db:add-status": "node develop-tools/add-status-column.js",
+    "db:add-posts": "node develop-tools/add-posts-from-json.js"
   },
   "dependencies": {
     "@babel/core": "^7.28.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
     "deploy": "gatsby build && gh-pages -d public",
     "db:migrate": "node develop-tools/migrate-devto-to-sqlite.js",
     "db:add-status": "node develop-tools/add-status-column.js",
-    "db:add-posts": "node develop-tools/add-posts-from-json.js"
+    "db:add-posts": "node develop-tools/add-posts-from-json.js",
+    "db:init": "node develop-tools/init-db.js",
+    "db:export": "node develop-tools/export-published-to-json.js",
+    "db:seed": "npm run db:init && npm run db:add-posts -- src/data/published-posts.json"
   },
   "dependencies": {
     "@babel/core": "^7.28.0",

--- a/src/components/loadingScreen.js
+++ b/src/components/loadingScreen.js
@@ -1,11 +1,10 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 
 const LoadingScreen = ({ onDismiss, isShort = false }) => {
   const [progress, setProgress] = useState(0);
-  const [visibleLogs, setVisibleLogs] = useState([]);
   const [isDismissing, setIsDismissing] = useState(false);
 
-  const logsList = isShort
+  const logsList = useMemo(() => (isShort
     ? [
         "> SYSTEM RESUMING...",
         "> DETECTING REFERRER: BLOG_POST",
@@ -22,7 +21,14 @@ const LoadingScreen = ({ onDismiss, isShort = false }) => {
         "> COMPILING NEUTRAL THEME...",
         "> LIVE THOUGHT STREAM: ONLINE",
         "> RETRO_UI v1.1.0 INITIALIZED"
-      ];
+      ]), [isShort]);
+
+  // Logs are revealed sequentially as the progress bar fills
+  const visibleLogs = useMemo(() => {
+    if (isShort) return [];
+    const logIndexToShow = Math.floor((progress / 100) * logsList.length);
+    return logsList.slice(0, Math.min(logIndexToShow + 1, logsList.length));
+  }, [progress, logsList, isShort]);
 
   useEffect(() => {
     if (isShort) return;
@@ -41,14 +47,6 @@ const LoadingScreen = ({ onDismiss, isShort = false }) => {
 
     return () => clearInterval(interval);
   }, [isShort]);
-
-  useEffect(() => {
-    if (isShort) return;
-    // Show logs sequentially based on progress
-    const logIndexToShow = Math.floor((progress / 100) * logsList.length);
-    const shownLogs = logsList.slice(0, Math.min(logIndexToShow + 1, logsList.length));
-    setVisibleLogs(shownLogs);
-  }, [progress, logsList, isShort]);
 
   const handleDismiss = () => {
     if ((!isShort && progress < 100) || isDismissing) return;

--- a/src/data/published-posts.json
+++ b/src/data/published-posts.json
@@ -1,0 +1,159 @@
+[
+  {
+    "title": "Data Structures: Linked Lists",
+    "description": "Today we are going to travel through crazy linked lists!",
+    "body_html": "<p>Today we are going to travel through crazy linked lists!</p>\n\n<p><iframe src=\"https://stackblitz.com/edit/js-nlivnb?ctl=1&amp;embed=1&amp;file=index.js&amp;hideExplorer=1&amp;hideNavigation=1&amp;theme=dark\" width=\"100%\" height=\"500\" scrolling=\"no\" frameborder=\"no\" allowfullscreen allowtransparency=\"true\" loading=\"lazy\">\n</iframe>\n</p>\n\n",
+    "slug": "data-structures-linked-lists-ffb",
+    "published_at": "2022-11-28T23:25:43Z",
+    "cover_image": "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Farticles%2Fmjhfu1d82kku6drlli7q.jpg",
+    "status": "published",
+    "tags": [
+      "emptystring"
+    ]
+  },
+  {
+    "title": "Data Structures: Map & Hash Table",
+    "description": "Ok, now it's time to hash!",
+    "body_html": "<p>Ok, now it's time to hash!</p>\n\n<p><iframe src=\"https://stackblitz.com/edit/js-52r3dx?ctl=1&amp;embed=1&amp;file=index.js&amp;hideExplorer=1&amp;hideNavigation=1&amp;theme=dark\" width=\"100%\" height=\"500\" scrolling=\"no\" frameborder=\"no\" allowfullscreen allowtransparency=\"true\" loading=\"lazy\">\n</iframe>\n</p>\n\n",
+    "slug": "data-structures-map-hash-table-186c",
+    "published_at": "2022-11-26T13:33:08Z",
+    "cover_image": "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Farticles%2Fkm2e9fk034kmnfmojrd9.jpg",
+    "status": "published",
+    "tags": [
+      "algorithms",
+      "beginners",
+      "javascript"
+    ]
+  },
+  {
+    "title": "Data Structures: Sets of Data",
+    "description": "Today we are going to win some sets!",
+    "body_html": "<p>Today we are going to win some sets!</p>\n\n<p><iframe src=\"https://stackblitz.com/edit/js-5wlhvy?ctl=1&amp;embed=1&amp;file=index.js&amp;hideExplorer=1&amp;hideNavigation=1&amp;theme=dark\" width=\"100%\" height=\"500\" scrolling=\"no\" frameborder=\"no\" allowfullscreen allowtransparency=\"true\" loading=\"lazy\">\n</iframe>\n</p>\n\n",
+    "slug": "data-structures-exercices-sets-of-data-1n07",
+    "published_at": "2022-11-19T23:09:47Z",
+    "cover_image": "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Farticles%2Flwlotmby6590oj4rfrsu.png",
+    "status": "published",
+    "tags": [
+      "watercooler"
+    ]
+  },
+  {
+    "title": "Data Structures: Stack/Queue",
+    "description": "Today we will learn about queues and stacks.  Where they live? What they eat? How they reproduce?",
+    "body_html": "<p>Today we will learn about queues and stacks.</p>\n\n<p>Where they live? What they eat? How they reproduce? </p>\n\n<p><iframe src=\"https://stackblitz.com/edit/js-cm9a8d?ctl=1&amp;embed=1&amp;file=index.js&amp;hideExplorer=1&amp;hideNavigation=1&amp;theme=dark\" width=\"100%\" height=\"500\" scrolling=\"no\" frameborder=\"no\" allowfullscreen allowtransparency=\"true\" loading=\"lazy\">\n</iframe>\n</p>\n\n",
+    "slug": "data-structures-exercicesstackqueue-4l1",
+    "published_at": "2022-09-14T23:05:07Z",
+    "cover_image": "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Farticles%2Fb7a6uwq2mxo6ld1uriul.png",
+    "status": "published",
+    "tags": [
+      "algorithms",
+      "beginners",
+      "javascript"
+    ]
+  },
+  {
+    "title": "Binary Tree Algorithms",
+    "description": "We love trees! Let's study the binary trees this time!",
+    "body_html": "<p>We love trees!<br>\nLet's study the binary trees this time!</p>\n\n<p><iframe src=\"https://stackblitz.com/edit/js-m5dgtd?ctl=1&amp;embed=1&amp;file=index.js&amp;hideExplorer=1&amp;hideNavigation=1&amp;theme=dark\" width=\"100%\" height=\"500\" scrolling=\"no\" frameborder=\"no\" allowfullscreen allowtransparency=\"true\" loading=\"lazy\">\n</iframe>\n</p>\n\n",
+    "slug": "binary-tree-algorithms-1cfp",
+    "published_at": "2022-09-07T18:59:43Z",
+    "cover_image": "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Farticles%2Fswise219m25rr30w8hi4.png",
+    "status": "published",
+    "tags": [
+      "algorithms",
+      "beginners",
+      "javascript"
+    ]
+  },
+  {
+    "title": "Big O Notation",
+    "description": "How bad are our code?   Let's figure it out, learning a little bit about Big O Notation!",
+    "body_html": "<p>How bad are our code? </p>\n\n<p>Let's figure it out, learning a little bit about Big O Notation!</p>\n\n<p><iframe src=\"https://stackblitz.com/edit/js-3n3rxx?ctl=1&amp;embed=1&amp;file=index.js&amp;hideExplorer=1&amp;hideNavigation=1&amp;theme=dark\" width=\"100%\" height=\"500\" scrolling=\"no\" frameborder=\"no\" allowfullscreen allowtransparency=\"true\" loading=\"lazy\">\n</iframe>\n</p>\n\n",
+    "slug": "big-o-notation-1n86",
+    "published_at": "2022-09-04T19:05:08Z",
+    "cover_image": "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Farticles%2F1519ii3jxd71i0ovpbfl.jpg",
+    "status": "published",
+    "tags": [
+      "algorithms",
+      "beginners",
+      "javascript"
+    ]
+  },
+  {
+    "title": "Game of Life [v1]",
+    "description": "Let's rest from the exercises of the last post and have some fun, coding something cool.  This is a...",
+    "body_html": "<p>Let's rest from the exercises of the last post and have some fun, coding something cool.</p>\n\n<p>This is a poor implementation of Conway`s game. More features coming soon.</p>\n\n<p><iframe src=\"https://stackblitz.com/edit/conway-s-game-of-life?ctl=1&amp;embed=1&amp;file=README.md&amp;hideExplorer=1&amp;hideNavigation=1&amp;theme=dark\" width=\"100%\" height=\"500\" scrolling=\"no\" frameborder=\"no\" allowfullscreen allowtransparency=\"true\" loading=\"lazy\">\n</iframe>\n</p>\n\n",
+    "slug": "game-of-life-3emh",
+    "published_at": "2022-08-26T15:20:00Z",
+    "cover_image": "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Farticles%2F9c1xdz3n775gdf13z747.png",
+    "status": "published",
+    "tags": [
+      "beginners",
+      "gamedev",
+      "javascript",
+      "p5js"
+    ]
+  },
+  {
+    "title": "Exercise Time!",
+    "description": "Ok, it's time to get harder, better, faster, stronger!",
+    "body_html": "<p>Ok, it's time to get harder, better, faster, stronger!</p>\n\n\n<div class=\"ltag__replit\">\n  <iframe frameborder=\"0\" height=\"550px\" src=\"https://repl.it/@thiagocolen/Java-Programming-Masterclass-5-Exercise-Time?lite=true\" loading=\"lazy\"></iframe>\n</div>\n\n\n",
+    "slug": "exercise-time-33kk",
+    "published_at": "2022-08-13T20:40:12Z",
+    "cover_image": "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Farticles%2Fyb57p5ockyarewno1yp0.jpg",
+    "status": "published",
+    "tags": [
+      "beginners",
+      "java"
+    ]
+  },
+  {
+    "title": "Methods and a Challenge",
+    "description": "...not so challenging ...not so challenging ...not so challenging",
+    "body_html": "<p>...not so challenging<br>\n...not so challenging<br>\n...not so challenging</p>\n\n\n<div class=\"ltag__replit\">\n  <iframe frameborder=\"0\" height=\"550px\" src=\"https://repl.it/@thiagocolen/Java-Programming-Masterclass-4-Methods-and-a-Challenge?lite=true\" loading=\"lazy\"></iframe>\n</div>\n\n\n",
+    "slug": "methods-and-a-challenge-1km3",
+    "published_at": "2022-07-17T17:15:19Z",
+    "cover_image": "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Farticles%2Fbp4y8jfxl763jylejzlx.jpg",
+    "status": "published",
+    "tags": []
+  },
+  {
+    "title": "Keywords and Expressions",
+    "description": "A keyword is a word that you can't use, it's a reserved word and just the JAVA language can use it....",
+    "body_html": "<p>A keyword is a word that you can't use, it's a reserved word and just the JAVA language can use it. Is it confuse? Expressions are more easy to understand...</p>\n\n\n<hr>\n\n\n<div class=\"ltag__replit\">\n  <iframe frameborder=\"0\" height=\"550px\" src=\"https://repl.it/@thiagocolen/Java-Programming-Masterclass-3-Keywords-and-Expressions?lite=true\" loading=\"lazy\"></iframe>\n</div>\n\n\n",
+    "slug": "keywords-and-expressions-14dd",
+    "published_at": "2022-07-13T15:32:12Z",
+    "cover_image": "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Farticles%2F8u83695kgwp6fi3w69q2.jpg",
+    "status": "published",
+    "tags": [
+      "beginners",
+      "java"
+    ]
+  },
+  {
+    "title": "Operators",
+    "description": "This is one more post of my java lessons. That's a long, long way to done.",
+    "body_html": "<p>This is one more post of my java lessons. That's a long, long way to done.</p>\n\n\n<hr>\n\n\n<div class=\"ltag__replit\">\n  <iframe frameborder=\"0\" height=\"550px\" src=\"https://repl.it/@thiagocolen/Java-Programming-Masterclass-2-Operators?lite=true\" loading=\"lazy\"></iframe>\n</div>\n\n\n",
+    "slug": "operators-java-1bn3",
+    "published_at": "2022-06-17T22:06:00Z",
+    "cover_image": "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Farticles%2Fbp1vz8dfe5ovi1pmjuw2.jpeg",
+    "status": "published",
+    "tags": [
+      "beginners",
+      "java"
+    ]
+  },
+  {
+    "title": "Primitive Types",
+    "description": "What are primitive types? This is my first study into java course. Let's figure it out.      This...",
+    "body_html": "<p>What are primitive types? This is my first study into java course. Let's figure it out.</p>\n\n\n<hr>\n\n<p><a href=\"https://res.cloudinary.com/practicaldev/image/fetch/s--xebGh6pr--/c_limit%2Cf_auto%2Cfl_progressive%2Cq_auto%2Cw_880/https://dev-to-uploads.s3.amazonaws.com/uploads/articles/2lcy7bq0wdkxeg4honly.png\" class=\"article-body-image-wrapper\"><img src=\"https://res.cloudinary.com/practicaldev/image/fetch/s--xebGh6pr--/c_limit%2Cf_auto%2Cfl_progressive%2Cq_auto%2Cw_880/https://dev-to-uploads.s3.amazonaws.com/uploads/articles/2lcy7bq0wdkxeg4honly.png\" alt=\"primitive types\" loading=\"lazy\" width=\"880\" height=\"493\"></a><br>\n<em>This image is from <a href=\"https://getkt.com/blog/reintroduction-to-java-data-types/\">https://getkt.com/blog/reintroduction-to-java-data-types/</a>, visit the site to get complete content.</em></p>\n\n<hr>\n\n\n<div class=\"ltag__replit\">\n  <iframe frameborder=\"0\" height=\"550px\" src=\"https://repl.it/@thiagocolen/Java-Programming-Masterclass-1-Primitive-Types?lite=true\" loading=\"lazy\"></iframe>\n</div>\n\n\n",
+    "slug": "one-two-one-two-3ha7",
+    "published_at": "2021-09-25T13:05:00Z",
+    "cover_image": "https://media2.dev.to/dynamic/image/width=1000,height=420,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Farticles%2Fhizc6p3rztqzfv80e9ks.jpg",
+    "status": "published",
+    "tags": [
+      "beginners",
+      "java"
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- Adds develop-tools/add-posts-from-json.js to import posts (from JSON) into the local SQLite database, with a JSON Schema and example
- Adds a GitHub Actions PR-preview pipeline (deploys every PR to https://thiagocolen.github.io/pr-preview/pr-<number>/), seeded via new db:init/db:export/db:seed scripts since the local posts.db is never committed
- Fixes a redundant state-sync effect in loadingScreen.js

## Test plan
- [ ] Confirm the "PR Preview" Action runs successfully on this PR
- [ ] Visit https://thiagocolen.github.io/pr-preview/pr-<this PR number>/ and confirm the site loads with posts intact
- [ ] Push a follow-up commit and confirm the preview refreshes
- [ ] Close/merge this PR and confirm the preview is torn down