### PR TITLE
feat: add an MCP publisher server for the article lifecycle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ target/
 prompt.md
 .gemini/
 .antigravitycli/
+
+# Git worktree the MCP publisher server writes posts into (branch: new-articles)
+.mcp-worktree/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "articles": {
+      "command": "node",
+      "args": ["mcp-server/index.js"]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 - ✍️ [Content](#-content)
 - ⚙️ [How the Site Works](#-how-the-site-works)
 - 🧰 [Available Scripts](#-available-scripts)
+- 🤖 [Publishing from an AI agent](#-publishing-from-an-ai-agent)
 - 👀 [PR Previews](#-pr-previews)
 - 🧠 [Development Philosophy](#-development-philosophy)
 
@@ -100,6 +101,42 @@ Posts are plain files under `content/posts/` — see [Content](#-content) for th
 | `publish-post` | `node develop-tools/publish-post.js <slug>` | Flips a post's `status` from `unpublished` to `published`. No-op (not an error) if already published. Sets `published_at` to the current time only if it isn't already set, so republishing after an edit never clobbers the original publish date. |
 
 After publishing, commit `content/posts/` and run `npm run deploy` (or push — see [PR Previews](#-pr-previews)) to ship it.
+
+## 🤖 Publishing from an AI agent
+
+`mcp-server/` is an [MCP](https://modelcontextprotocol.io) server that exposes the post lifecycle as typed tools, so an AI agent (Claude Code, Claude Desktop, Cursor — anything that speaks MCP) can draft, edit and publish articles without guessing at shell commands.
+
+It's registered in `.mcp.json`, so Claude Code picks it up automatically in this repo. Install its dependencies once:
+
+```bash
+cd mcp-server && npm install
+```
+
+| Tool | What it does |
+| :--- | :--- |
+| `list_posts` | Every article with slug, title, status, date and tags |
+| `read_post` | One article's frontmatter and MDX body |
+| `create_draft` | New `.mdx` with `status: unpublished`; refuses to overwrite |
+| `update_post` | Partial update of metadata and/or body |
+| `publish_post` | Flip to `published` and stamp `published_at` |
+| `stage_changes` | Commit and push the posts to the `new-articles` branch |
+
+All tools share `develop-tools/posts.js` with the npm scripts above, so the CLI and the agent can't drift apart.
+
+### Where the agent can and can't reach
+
+The agent writes to a **separate git worktree** at `.mcp-worktree/` (gitignored), checked out to a branch called `new-articles`. Two things follow from that:
+
+- **Your working tree is never touched.** You can be mid-edit or mid-rebase on another branch while the agent works.
+- **Nothing the agent does can reach the live site.** No workflow builds `new-articles` — `pr-preview.yml` triggers on `pull_request`, not `push`. The agent stages; *you* open the PR, which is what triggers the preview build, and `npm run deploy` stays manual.
+
+```
+agent → new-articles → you open a PR → preview build → merge → npm run deploy
+```
+
+`new-articles` is branched from whatever the main working tree has checked out the first time the worktree is created (override with `MCP_BASE_BRANCH`). Note this is deliberately *not* `master` — until `release/v1.2.0` lands, master predates the MDX pipeline and has no `content/posts` at all.
+
+One tradeoff worth knowing: because agent drafts live on `new-articles`, `npm run develop` in the repo root won't show them. Check out `new-articles` yourself to preview locally, or open the PR and use the preview URL.
 
 ## 👀 PR Previews
 

--- a/develop-tools/new-post.js
+++ b/develop-tools/new-post.js
@@ -1,10 +1,11 @@
 // Scaffolds a new draft post.
 //
 //   npm run new-post -- "My Post Title" tag1,tag2
+//
+// Logic lives in posts.js, shared with the MCP server.
 
 const path = require("path");
-const fs = require("fs");
-const matter = require("gray-matter");
+const { createDraft } = require("./posts");
 
 const POSTS_DIR = path.resolve(__dirname, "../content/posts");
 
@@ -19,32 +20,12 @@ if (!title) {
   process.exit(1);
 }
 
-const slug = title
-  .toLowerCase()
-  .trim()
-  .replace(/[^a-z0-9]+/g, "-")
-  .replace(/^-+|-+$/g, "");
+try {
+  const { path: outPath } = createDraft(POSTS_DIR, { title, tags });
 
-const outPath = path.join(POSTS_DIR, `${slug}.mdx`);
-
-if (fs.existsSync(outPath)) {
-  console.error(`Refusing to overwrite existing post: ${outPath}`);
+  console.log(`Created ${outPath}`);
+  console.log(`Preview it with: npm run develop`);
+} catch (error) {
+  console.error(error.message);
   process.exit(1);
 }
-
-const frontmatter = {
-  title,
-  description: "",
-  published_at: null,
-  cover_image: "",
-  status: "unpublished",
-  tags,
-};
-
-const file = matter.stringify("\nWrite your post here.\n", frontmatter);
-
-fs.mkdirSync(POSTS_DIR, { recursive: true });
-fs.writeFileSync(outPath, file);
-
-console.log(`Created ${outPath}`);
-console.log(`Preview it with: npm run develop`);

--- a/develop-tools/posts.js
+++ b/develop-tools/posts.js
@@ -1,0 +1,305 @@
+// Post lifecycle: the single source of truth for how an MDX post is shaped,
+// created, and mutated.
+//
+// Every entry point takes `postsDir` rather than resolving it here — the CLI
+// scripts pass the repo's content/posts/, while the MCP server points at a
+// separate git worktree so it can commit without touching your working tree.
+
+const path = require("path");
+const fs = require("fs");
+const matter = require("gray-matter");
+
+// The frontmatter contract. gatsby-node.js queries exactly these fields, so
+// adding one here means adding it to that GraphQL query too.
+const FRONTMATTER_FIELDS = [
+  "title",
+  // Subtitle shown under the title on the post page. Distinct from
+  // `description`, which is the listing/SEO blurb and is not rendered there.
+  "headline",
+  "description",
+  "published_at",
+  "cover_image",
+  "status",
+  "tags",
+];
+
+const SLUG_PATTERN = /^[a-z0-9-]+$/;
+
+// Local images live under static/, which Gatsby copies verbatim to the site
+// root — so static/images/foo.png is served at /images/foo.png with no plugin
+// involved. Deliberately not gatsby-plugin-image: sharp is in package.json but
+// absent from gatsby-config.js, so there is no transform pipeline to hook into.
+// The trade-off is no responsive/optimised variants for these files.
+//
+// These two must agree: ASSETS_SUBPATH is where bytes land, ASSET_URL_BASE is
+// how a post references them.
+const ASSETS_SUBPATH = path.join("static", "images");
+const ASSET_URL_BASE = "/images";
+
+// Filenames become URLs and paths, so they are never trusted. The pattern
+// allows no separators and no leading dot, which already rules out traversal;
+// the resolved-path check below is the belt-and-braces backstop, matching
+// postPath's posture.
+const ASSET_PATTERN = /^[a-z0-9][a-z0-9._-]*\.(png|jpe?g|gif|webp|svg|avif)$/i;
+
+const slugify = (title) =>
+  title
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+// A slug becomes a filename, so it is never trusted. Reject anything outside
+// the pattern, then confirm the resolved path really is inside postsDir —
+// belt-and-braces against a pattern bug ever letting a traversal through.
+const postPath = (postsDir, slug) => {
+  if (typeof slug !== "string" || !SLUG_PATTERN.test(slug)) {
+    throw new Error(
+      `Invalid slug: ${JSON.stringify(slug)} (expected only a-z, 0-9 and hyphens)`
+    );
+  }
+
+  const dir = path.resolve(postsDir);
+  const file = path.resolve(dir, `${slug}.mdx`);
+
+  if (path.dirname(file) !== dir) {
+    throw new Error(`Refusing to resolve ${slug} outside ${dir}`);
+  }
+
+  return file;
+};
+
+const assetPath = (assetsDir, filename) => {
+  if (typeof filename !== "string" || !ASSET_PATTERN.test(filename)) {
+    throw new Error(
+      `Invalid asset filename: ${JSON.stringify(filename)} (expected e.g. "diagram-1.png"; letters, digits, dot, dash and underscore only, with an image extension)`
+    );
+  }
+
+  const dir = path.resolve(assetsDir);
+  const file = path.resolve(dir, filename);
+
+  if (path.dirname(file) !== dir) {
+    throw new Error(`Refusing to resolve ${filename} outside ${dir}`);
+  }
+
+  return file;
+};
+
+// Writes a base64-encoded image into static/images/ and returns the URL a post
+// body should reference. Refuses to overwrite by default, mirroring createDraft.
+const addAsset = (assetsDir, { filename, content, overwrite = false }) => {
+  const file = assetPath(assetsDir, filename);
+
+  if (fs.existsSync(file) && !overwrite) {
+    throw new Error(
+      `Refusing to overwrite existing asset: ${file} (pass overwrite: true if that is intended)`
+    );
+  }
+
+  if (typeof content !== "string" || !content.trim()) {
+    throw new Error("Asset content is required (base64-encoded image bytes)");
+  }
+
+  // Agents commonly send a full data URI; accept it rather than writing the
+  // header into the file and producing a silently corrupt image.
+  const base64 = content.replace(/^data:[^;,]*;base64,/, "").trim();
+
+  // Buffer.from(..., "base64") ignores invalid characters instead of throwing,
+  // so a malformed payload would otherwise be written as a truncated image.
+  if (!/^[A-Za-z0-9+/\r\n]+={0,2}$/.test(base64)) {
+    throw new Error("Asset content is not valid base64");
+  }
+
+  const bytes = Buffer.from(base64, "base64");
+
+  if (!bytes.length) {
+    throw new Error("Asset content decoded to zero bytes");
+  }
+
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, bytes);
+
+  return {
+    filename,
+    path: file,
+    // What goes in the post body / cover_image.
+    url: `${ASSET_URL_BASE}/${filename}`,
+    bytes: bytes.length,
+  };
+};
+
+const listPosts = (postsDir) => {
+  const dir = path.resolve(postsDir);
+
+  if (!fs.existsSync(dir)) return [];
+
+  return fs
+    .readdirSync(dir)
+    .filter((name) => name.endsWith(".mdx"))
+    .map((name) => {
+      const slug = path.basename(name, ".mdx");
+      const { data } = matter.read(path.join(dir, name));
+
+      return {
+        slug,
+        title: data.title || "",
+        headline: data.headline || "",
+        description: data.description || "",
+        status: data.status || "unpublished",
+        published_at: data.published_at || null,
+        tags: data.tags || [],
+      };
+    })
+    // published_at DESC; drafts (no published_at) sort last — same ordering
+    // gatsby-node.js applies, so listings match what the site shows.
+    .sort((a, b) => {
+      if (!a.published_at) return 1;
+      if (!b.published_at) return -1;
+      return new Date(b.published_at) - new Date(a.published_at);
+    });
+};
+
+const readPost = (postsDir, slug) => {
+  const file = postPath(postsDir, slug);
+
+  if (!fs.existsSync(file)) {
+    throw new Error(`No post found at ${file}`);
+  }
+
+  const { data, content } = matter.read(file);
+  return { slug, frontmatter: data, body: content };
+};
+
+const createDraft = (
+  postsDir,
+  { title, headline = "", description = "", cover_image = "", tags = [], body }
+) => {
+  if (!title || !title.trim()) {
+    throw new Error("A title is required");
+  }
+
+  const slug = slugify(title);
+
+  if (!slug) {
+    throw new Error(
+      `Title ${JSON.stringify(title)} produces an empty slug — it needs at least one letter or digit`
+    );
+  }
+
+  const dir = path.resolve(postsDir);
+  const file = postPath(dir, slug);
+
+  if (fs.existsSync(file)) {
+    throw new Error(`Refusing to overwrite existing post: ${file}`);
+  }
+
+  // Key order mirrors FRONTMATTER_FIELDS so every generated file looks the same.
+  const frontmatter = {
+    title,
+    headline,
+    description,
+    published_at: null,
+    cover_image,
+    status: "unpublished",
+    tags,
+  };
+
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    file,
+    matter.stringify(body || "\nWrite your post here.\n", frontmatter)
+  );
+
+  return { slug, path: file };
+};
+
+// Partial merge: only the keys you pass are touched. `status` and
+// `published_at` are deliberately not updatable here — publishPost owns those,
+// so publish-date semantics live in exactly one place.
+const updatePost = (postsDir, slug, { body, ...fields }) => {
+  const file = postPath(postsDir, slug);
+
+  if (!fs.existsSync(file)) {
+    throw new Error(`No post found at ${file}`);
+  }
+
+  const editable = ["title", "headline", "description", "cover_image", "tags"];
+  const rejected = Object.keys(fields).filter((k) => !editable.includes(k));
+
+  if (rejected.length) {
+    throw new Error(
+      `Cannot update ${rejected.join(", ")} — editable fields are ${editable.join(", ")} and body. Use publish_post to change status.`
+    );
+  }
+
+  const supplied = Object.entries(fields).filter(([, v]) => v !== undefined);
+
+  // A caller that asked for a change and got none must hear about it. MCP
+  // clients validate against the tool schema and silently strip unknown keys,
+  // so a request like {status: "unpublished"} arrives here empty — without
+  // this, the agent would read "ok" and believe it had changed the status.
+  if (!supplied.length && body === undefined) {
+    throw new Error(
+      `Nothing to update on ${slug}. Pass at least one of: ${editable.join(", ")}, body. To change status, use publishPost.`
+    );
+  }
+
+  const post = matter.read(file);
+
+  for (const [key, value] of supplied) {
+    post.data[key] = value;
+  }
+
+  const content = body === undefined ? post.content : body;
+
+  fs.writeFileSync(file, matter.stringify(content, post.data));
+
+  return {
+    slug,
+    path: file,
+    updated: supplied.map(([key]) => key).concat(body === undefined ? [] : ["body"]),
+  };
+};
+
+// Sets published_at only if it isn't already set, so republishing after an
+// edit never clobbers the original publish date.
+const publishPost = (postsDir, slug) => {
+  const file = postPath(postsDir, slug);
+
+  if (!fs.existsSync(file)) {
+    throw new Error(`No post found at ${file}`);
+  }
+
+  const post = matter.read(file);
+
+  if (post.data.status === "published") {
+    return { slug, path: file, alreadyPublished: true, published_at: post.data.published_at };
+  }
+
+  post.data.status = "published";
+  if (!post.data.published_at) {
+    post.data.published_at = new Date().toISOString();
+  }
+
+  fs.writeFileSync(file, matter.stringify(post.content, post.data));
+
+  return { slug, path: file, alreadyPublished: false, published_at: post.data.published_at };
+};
+
+module.exports = {
+  FRONTMATTER_FIELDS,
+  SLUG_PATTERN,
+  ASSETS_SUBPATH,
+  ASSET_URL_BASE,
+  ASSET_PATTERN,
+  slugify,
+  postPath,
+  assetPath,
+  addAsset,
+  listPosts,
+  readPost,
+  createDraft,
+  updatePost,
+  publishPost,
+};

--- a/develop-tools/publish-post.js
+++ b/develop-tools/publish-post.js
@@ -5,10 +5,11 @@
 // No-op (not an error) if already published. Sets published_at to the
 // current time only if it isn't already set, so republishing after an edit
 // never clobbers the original publish date.
+//
+// Logic lives in posts.js, shared with the MCP server.
 
 const path = require("path");
-const fs = require("fs");
-const matter = require("gray-matter");
+const { publishPost } = require("./posts");
 
 const POSTS_DIR = path.resolve(__dirname, "../content/posts");
 
@@ -19,26 +20,17 @@ if (!slug) {
   process.exit(1);
 }
 
-const filePath = path.join(POSTS_DIR, `${slug}.mdx`);
+try {
+  const result = publishPost(POSTS_DIR, slug);
 
-if (!fs.existsSync(filePath)) {
-  console.error(`No post found at ${filePath}`);
+  if (result.alreadyPublished) {
+    console.log(`${slug} is already published.`);
+    process.exit(0);
+  }
+
+  console.log(`Published ${slug} (published_at: ${result.published_at})`);
+  console.log("Commit content/posts/ and run `npm run deploy` to ship it.");
+} catch (error) {
+  console.error(error.message);
   process.exit(1);
 }
-
-const file = matter.read(filePath);
-
-if (file.data.status === "published") {
-  console.log(`${slug} is already published.`);
-  process.exit(0);
-}
-
-file.data.status = "published";
-if (!file.data.published_at) {
-  file.data.published_at = new Date().toISOString();
-}
-
-fs.writeFileSync(filePath, matter.stringify(file.content, file.data));
-
-console.log(`Published ${slug} (published_at: ${file.data.published_at})`);
-console.log("Commit content/posts/ and run `npm run deploy` to ship it.");

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,6 +1,10 @@
 import "./src/styles/global.css"
 import "./src/styles/fix.css"
 
+// Makes <Callout> and the pathPrefix-aware <img> available in MDX post bodies.
+// Must stay in sync with the same export in gatsby-ssr.js.
+export { wrapRootElement } from "./src/wrapRootElement";
+
 // Smoothly animate scroll to the top on every page navigation
 export const onRouteUpdate = () => {
   if (typeof window !== "undefined") {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -8,6 +8,7 @@ exports.createPages = async ({ actions: { createPage }, graphql }) => {
           id
           frontmatter {
             title
+            headline
             description
             published_at
             cover_image

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,3 +1,23 @@
+// Gatsby infers the GraphQL schema from the frontmatter that posts actually
+// use, so an optional field no post has set yet does not exist on the type and
+// querying it fails the build. `headline` is exactly that case: the MCP server
+// can write it and postPage.js renders it, but no published post carries one.
+// Declaring the frontmatter explicitly keeps the schema stable no matter which
+// optional fields the current set of posts happens to use.
+exports.createSchemaCustomization = ({ actions: { createTypes } }) => {
+  createTypes(`
+    type MdxFrontmatter {
+      title: String
+      headline: String
+      description: String
+      published_at: Date @dateformat
+      cover_image: String
+      status: String
+      tags: [String]
+    }
+  `);
+};
+
 exports.createPages = async ({ actions: { createPage }, graphql }) => {
   const isDevelopEnv = process.env.NODE_ENV === "development";
 

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,5 +1,10 @@
 const React = require("react");
 
+// Same provider gatsby-browser.js registers, so the SSR'd HTML and the
+// hydrated app render post bodies identically. This file is CommonJS (it uses
+// `exports.` below), hence require rather than import.
+exports.wrapRootElement = require("./src/wrapRootElement").wrapRootElement;
+
 const HtmlAttributes = {};
 
 const HeadComponents = [

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,0 +1,119 @@
+# `articles` MCP server
+
+An MCP server exposing the article lifecycle as typed tools, so an agent can draft,
+revise and publish posts without shelling out to the npm scripts.
+
+Configured in `.mcp.json` at the repo root:
+
+```json
+{
+  "mcpServers": {
+    "articles": {
+      "command": "node",
+      "args": ["mcp-server/index.js"]
+    }
+  }
+}
+```
+
+Run it by hand with the inspector:
+
+```sh
+npx @modelcontextprotocol/inspector node mcp-server/index.js
+```
+
+## Tools
+
+| Tool | What it does |
+|---|---|
+| `list_posts` | All articles: slug, title, headline, status, date, tags. Optional `status` filter (`published` / `unpublished`). |
+| `read_post` | Full frontmatter + MDX body for one slug. |
+| `create_draft` | New `.mdx` as an unpublished draft. Slug derived from the title. Fails rather than overwriting. |
+| `update_post` | Patch title / headline / description / tags / cover_image / body on an existing slug. Only fields you pass change. |
+| `publish_post` | Flips status to published and stamps `published_at`. No-op if already published, never rewrites an existing date. |
+| `add_asset` | Writes a base64 image into `static/images/` and returns the `/images/…` URL to reference it by. Refuses to overwrite unless asked. |
+| `stage_changes` | Commits posts *and* assets, pushes to the `new-articles` branch. Returns a compare URL. |
+
+## The article shape
+
+`headline` and `description` are different things and the tools describe them
+separately, because an authoring agent will otherwise conflate them:
+
+- **`headline`** — the deck/subtitle rendered under the `<h1>` on the post page.
+- **`description`** — the listing blurb. Shown on article cards, *not* on the
+  post page itself.
+
+Rich content goes in the body as MDX. Beyond plain HTML you get:
+
+- `<Callout type="note|tip|warn" title="OPTIONAL">…</Callout>` — see
+  `src/components/callout.js`. An unrecognised `type` degrades to `note`.
+- the [mdx-embed](https://www.mdx-embed.com/) shortcodes (`<YouTube>`,
+  `<CodePen>`, `<Tweet>`, …), which need no import.
+
+Both are provided by the `MDXProvider` in `src/wrapRootElement.js`, registered
+from *both* `gatsby-browser.js` and `gatsby-ssr.js`. A component missing from
+that map does not degrade — it fails to render.
+
+## Images
+
+Two options, both valid:
+
+- **Already hosted** — pass the URL straight to `cover_image` or put it in an
+  `<img>` in the body. Every imported dev.to post works this way. No upload.
+- **Local** — `add_asset` writes the bytes to `static/images/` and hands back a
+  `/images/…` path. Gatsby copies `static/` verbatim to the site root.
+
+Local images are served as-is: `gatsby-plugin-sharp` / `gatsby-plugin-image` are
+in `package.json` but not enabled in `gatsby-config.js`, so there is no
+responsive/optimised variant pipeline to hook into. Large source files ship at
+full size.
+
+Post bodies reference local images root-relative (`/images/foo.png`), and PR
+previews build under a path prefix (`/pr-preview/pr-N/`). `src/utils/assetUrl.js`
+reconciles those — it is applied to every `<img>` via the MDXProvider and to
+`cover_image` in `postPage.js` / `articleList.js`. Remote URLs pass through
+untouched. Skipping it produces images that work locally and in production but
+404 in the preview, which is the one place the post gets reviewed.
+
+## Where the files live
+
+None of these tools touch your working tree. The server keeps a separate git
+worktree at `.mcp-worktree/`, checked out to the `new-articles` branch. Posts
+live in `.mcp-worktree/content/posts/` and images in
+`.mcp-worktree/static/images/` (see `PATHS` in `git.js` — the commit pathspec is
+an explicit allowlist, so an unrelated dirty file can never ride along). You can
+be mid-edit on any branch and article writing won't collide with it.
+
+The base branch for `new-articles` is inferred from whatever branch you are
+currently on (`master` if you are already on `new-articles`), overridable with
+`MCP_BASE_BRANCH`.
+
+All post logic is delegated to `develop-tools/posts.js` — the same module the npm
+scripts use, so the CLI and the agent can never drift apart.
+
+## The flow
+
+```
+add_asset (optional, for local images)
+     │
+     ▼
+create_draft ──► update_post (iterate) ──► publish_post ──► stage_changes ──► open PR
+                      ▲                                          │
+                      └────── read_post to inspect ──────────────┘
+```
+
+1. **Draft** — `create_draft` writes the file with `status: unpublished`. It is on
+   disk in the worktree, uncommitted. `add_asset` first if the post needs local
+   images, so the returned URLs can go straight into the body.
+2. **Iterate** — `read_post` / `update_post` as many times as you like. Still local,
+   still uncommitted.
+3. **Publish** — `publish_post` only edits frontmatter. Nothing is live yet; this is
+   a file change, not a deploy.
+4. **Stage** — `stage_changes` commits and pushes to `new-articles`. Deliberately, no
+   CI workflow builds that branch, so pushing still does not publish anything to the web.
+5. **PR** — open a pull request from the returned compare URL. That is what triggers
+   the preview build and, on merge, the deploy.
+
+There are two independent gates before anything goes public: `publish_post` (the
+post's own status flag) and the pull request (the actual deploy). Steps 1–4 are all
+reversible; only merging the PR is outward-facing.

--- a/mcp-server/git.js
+++ b/mcp-server/git.js
@@ -1,0 +1,154 @@
+// Git plumbing for the publisher tool.
+//
+// Everything happens inside a dedicated worktree checked out to `new-articles`,
+// never the repo's main working tree. That way the agent can commit and push
+// while you're mid-edit on another branch, and it can never land a commit on
+// whatever you happen to have checked out.
+//
+// execFile (not exec) throughout: arguments are passed as an array, so a slug
+// or commit message can never reach a shell.
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { createRequire } from "node:module";
+import path from "node:path";
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const run = promisify(execFile);
+const require = createRequire(import.meta.url);
+
+// Where assets live is posts.js's decision; importing it keeps this file from
+// becoming a second place that has to be kept in sync.
+const { ASSETS_SUBPATH } = require("../develop-tools/posts.js");
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+export const REPO_ROOT = path.resolve(HERE, "..");
+export const WORKTREE = path.join(REPO_ROOT, ".mcp-worktree");
+export const POSTS_DIR = path.join(WORKTREE, "content", "posts");
+export const ASSETS_DIR = path.join(WORKTREE, ASSETS_SUBPATH);
+
+// Everything the agent is allowed to commit, as git pathspecs (POSIX
+// separators — git does not accept backslashes here even on Windows).
+// An explicit allowlist, not a convenience: it is what keeps an unrelated
+// dirty file in the worktree out of the agent's commits.
+const PATHS = ["content/posts", ASSETS_SUBPATH.split(path.sep).join("/")];
+
+// Hardcoded on purpose — not a parameter. This is the safety boundary: no
+// workflow builds this branch, so nothing the agent pushes can reach the
+// public site without a human opening a PR.
+export const BRANCH = "new-articles";
+
+const git = async (args, cwd = REPO_ROOT) => {
+  const { stdout } = await run("git", args, { cwd });
+  return stdout.trim();
+};
+
+const branchExists = async (ref) => {
+  try {
+    await git(["rev-parse", "--verify", "--quiet", ref]);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+// Which branch `new-articles` is cut from, and what its pull request targets.
+//
+// NOT origin/master: as of this writing master predates the MDX content
+// pipeline (it still carries the SQLite-era gatsby-node.js and no
+// content/posts at all), so a branch based there would hold zero existing
+// posts and its PR would read as a revert. Defaulting to whatever the main
+// working tree has checked out guarantees the base has the same content
+// pipeline you're editing against, and it self-corrects once a release lands
+// on master. Override with MCP_BASE_BRANCH when that isn't what you want.
+const resolveBase = async () => {
+  if (process.env.MCP_BASE_BRANCH) return process.env.MCP_BASE_BRANCH;
+
+  const current = await git(["branch", "--show-current"]);
+
+  // Detached HEAD gives an empty string; the branch can't be its own base.
+  if (!current || current === BRANCH) return "master";
+
+  return current;
+};
+
+// Lazily prepares the worktree and returns the posts directory to operate on.
+// Safe to call on every tool invocation: each step is a no-op once satisfied.
+export const ensureWorktree = async () => {
+  if (!fs.existsSync(WORKTREE)) {
+    if (await branchExists(BRANCH)) {
+      await git(["worktree", "add", WORKTREE, BRANCH]);
+    } else {
+      const base = await resolveBase();
+
+      await git(["worktree", "add", "-b", BRANCH, WORKTREE, base]);
+      // Remember the base so the PR link keeps pointing at it even after you
+      // switch branches in the main tree.
+      await git(["config", "mcp.baseBranch", base]);
+    }
+  }
+
+  // Pull only if the branch is already on the remote and fast-forwards
+  // cleanly. A diverged branch is a human's problem to resolve — never
+  // rebase or merge on the agent's behalf.
+  try {
+    await git(["pull", "--ff-only", "origin", BRANCH], WORKTREE);
+  } catch {
+    // No upstream yet, or it diverged. Either way, keep going: the commit
+    // succeeds locally and `push` below will surface a real conflict.
+  }
+
+  fs.mkdirSync(POSTS_DIR, { recursive: true });
+  fs.mkdirSync(ASSETS_DIR, { recursive: true });
+
+  return { postsDir: POSTS_DIR, assetsDir: ASSETS_DIR };
+};
+
+export const pendingChanges = async () => {
+  const status = await git(
+    ["status", "--porcelain", "--", ...PATHS],
+    WORKTREE
+  );
+
+  return status ? status.split("\n").map((line) => line.trim()) : [];
+};
+
+// Commits and pushes only the PATHS allowlist. The pathspec means that even if
+// something else in the worktree is dirty, it stays out of the commit.
+export const commitAndPush = async (message) => {
+  const changes = await pendingChanges();
+
+  if (!changes.length) {
+    return { pushed: false, reason: `No changes under ${PATHS.join(", ")} to commit.` };
+  }
+
+  await git(["add", "--", ...PATHS], WORKTREE);
+  await git(["commit", "-m", message, "--", ...PATHS], WORKTREE);
+  await git(["push", "--set-upstream", "origin", BRANCH], WORKTREE);
+
+  const sha = await git(["rev-parse", "--short", "HEAD"], WORKTREE);
+  const remote = await git(["remote", "get-url", "origin"]);
+  const repo = remote
+    .replace(/^git@github\.com:/, "")
+    .replace(/^https:\/\/github\.com\//, "")
+    .replace(/\.git$/, "");
+
+  let base = "master";
+  try {
+    base = await git(["config", "--get", "mcp.baseBranch"]);
+  } catch {
+    // Worktree predates the config, or it was cleared. `master` is a safe
+    // fallback for a link — the PR target is editable in GitHub's UI anyway.
+  }
+
+  return {
+    pushed: true,
+    sha,
+    branch: BRANCH,
+    base,
+    changes,
+    compareUrl: `https://github.com/${repo}/compare/${base}...${BRANCH}?expand=1`,
+  };
+};

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+// MCP server exposing the article lifecycle as typed tools.
+//
+//   node mcp-server/index.js          (stdio; started by the MCP client)
+//   npx @modelcontextprotocol/inspector node mcp-server/index.js
+//
+// All post logic is delegated to develop-tools/posts.js — the same module the
+// npm scripts use, so the CLI and the agent can never drift apart. Writes land
+// in a git worktree on `new-articles` (see git.js), never your working tree.
+
+import { createRequire } from "node:module";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+
+import { ensureWorktree, commitAndPush, pendingChanges, BRANCH } from "./git.js";
+
+// posts.js is CommonJS; createRequire is the unambiguous way to load it from ESM.
+const require = createRequire(import.meta.url);
+const posts = require("../develop-tools/posts.js");
+
+const server = new McpServer({ name: "articles", version: "1.0.0" });
+
+const slug = z
+  .string()
+  .regex(/^[a-z0-9-]+$/, "Slug may contain only lowercase letters, digits and hyphens");
+
+// Both forms are valid and render identically; the agent needs to know the
+// local one exists, otherwise it has no reason to reach for add_asset.
+const COVER_IMAGE_HINT =
+  "Cover image: either an absolute URL (https://...) or the site-relative path returned by add_asset (/images/...)";
+
+// Tool handlers return text; a thrown error becomes an MCP error the model can
+// read and correct. Wrapping here keeps every handler free of try/catch.
+const tool = (handler) => async (args) => {
+  try {
+    // { postsDir, assetsDir } — both live inside the worktree.
+    const dirs = await ensureWorktree();
+    const result = await handler(args, dirs);
+
+    return {
+      content: [
+        { type: "text", text: typeof result === "string" ? result : JSON.stringify(result, null, 2) },
+      ],
+    };
+  } catch (error) {
+    return {
+      isError: true,
+      content: [{ type: "text", text: error.message }],
+    };
+  }
+};
+
+server.registerTool(
+  "list_posts",
+  {
+    title: "List posts",
+    description:
+      "List every article with its slug, title, status, publish date and tags. Newest published first, drafts last.",
+    inputSchema: {
+      status: z
+        .enum(["published", "unpublished"])
+        .optional()
+        .describe("Filter by status. Omit for all posts."),
+    },
+  },
+  tool(({ status }, { postsDir }) => {
+    const all = posts.listPosts(postsDir);
+    return status ? all.filter((p) => p.status === status) : all;
+  })
+);
+
+server.registerTool(
+  "read_post",
+  {
+    title: "Read a post",
+    description: "Return one article's full frontmatter and MDX body.",
+    inputSchema: { slug: slug.describe("The post's slug (its filename without .mdx)") },
+  },
+  tool(({ slug }, { postsDir }) => posts.readPost(postsDir, slug))
+);
+
+server.registerTool(
+  "create_draft",
+  {
+    title: "Create a draft",
+    description:
+      "Create a new article as an unpublished draft. The slug is derived from the title. Fails rather than overwriting an existing post.",
+    inputSchema: {
+      title: z.string().min(1).describe("Article title; also the source of the slug"),
+      headline: z
+        .string()
+        .optional()
+        .describe("Subtitle/deck shown under the title on the post page"),
+      description: z
+        .string()
+        .optional()
+        .describe("Short summary shown in listings and search results, not on the post page"),
+      cover_image: z.string().optional().describe(COVER_IMAGE_HINT),
+      tags: z.array(z.string()).optional().describe("Topic tags, e.g. ['nodejs', 'javascript']"),
+      body: z.string().optional().describe("MDX body. Omit for a placeholder."),
+    },
+  },
+  tool((args, { postsDir }) => posts.createDraft(postsDir, args))
+);
+
+server.registerTool(
+  "update_post",
+  {
+    title: "Update a post",
+    description:
+      "Update an existing article's metadata and/or body. Only the fields you pass are changed. Use publish_post to change status.",
+    inputSchema: {
+      slug: slug.describe("The post to update"),
+      title: z.string().optional(),
+      headline: z
+        .string()
+        .optional()
+        .describe("Subtitle/deck shown under the title on the post page"),
+      description: z
+        .string()
+        .optional()
+        .describe("Short summary shown in listings and search results, not on the post page"),
+      cover_image: z.string().optional().describe(COVER_IMAGE_HINT),
+      tags: z.array(z.string()).optional(),
+      body: z.string().optional().describe("Replacement MDX body"),
+    },
+  },
+  tool(({ slug, ...fields }, { postsDir }) => posts.updatePost(postsDir, slug, fields))
+);
+
+server.registerTool(
+  "publish_post",
+  {
+    title: "Publish a post",
+    description:
+      "Mark a draft as published and stamp published_at. A no-op if already published; never overwrites an existing publish date. This only changes the file — run stage_changes to push it.",
+    inputSchema: { slug: slug.describe("The post to publish") },
+  },
+  tool(({ slug }, { postsDir }) => posts.publishPost(postsDir, slug))
+);
+
+server.registerTool(
+  "add_asset",
+  {
+    title: "Add an image asset",
+    description:
+      "Write a base64-encoded image into the site's static assets and return the URL to reference it by. Use the returned url in a post body (<img src=\"...\">) or as cover_image. Remote images that are already hosted need no upload — pass their URL directly instead.",
+    inputSchema: {
+      filename: z
+        .string()
+        .describe("Target filename with extension, e.g. 'lenia-grid.png'. No directories."),
+      content: z
+        .string()
+        .describe("The image bytes, base64-encoded. A full data: URI is also accepted."),
+      overwrite: z
+        .boolean()
+        .optional()
+        .describe("Replace the file if it already exists. Defaults to false."),
+    },
+  },
+  tool((args, { assetsDir }) => posts.addAsset(assetsDir, args))
+);
+
+server.registerTool(
+  "stage_changes",
+  {
+    title: "Stage changes for review",
+    description:
+      `Commit all post and asset changes and push them to the '${BRANCH}' branch. No workflow builds that branch, so nothing goes live — open a pull request from it to trigger a preview and deploy. Returns a compare URL.`,
+    inputSchema: {
+      message: z.string().optional().describe("Commit message. Defaults to a summary of what changed."),
+    },
+  },
+  tool(async ({ message }) => {
+    const changes = await pendingChanges();
+
+    if (!changes.length) {
+      return `Nothing to stage — no post or asset changes on ${BRANCH}.`;
+    }
+
+    return commitAndPush(message || `content: update ${changes.length} file(s)`);
+  })
+);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,0 +1,1284 @@
+{
+  "name": "thiago-colen-mcp-publisher",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "thiago-colen-mcp-publisher",
+      "version": "1.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.0",
+        "gray-matter": "^4.0.3",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
+      "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.31",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
+      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "thiago-colen-mcp-publisher",
+  "version": "1.0.0",
+  "private": true,
+  "description": "MCP server exposing the article lifecycle to AI agents",
+  "type": "module",
+  "main": "index.js",
+  "comment": "Deliberately isolated from the root package.json: that tree is Gatsby 3 / React 17 and needs --legacy-peer-deps. Keeping the SDK here avoids a resolution fight.",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.0",
+    "gray-matter": "^4.0.3",
+    "zod": "^3.23.8"
+  }
+}

--- a/src/components/articleList.js
+++ b/src/components/articleList.js
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { Link } from "gatsby";
 import { datePipe } from "../utils/datePipe";
+import { assetUrl } from "../utils/assetUrl";
 
 const ArticleComponent = ({ article, index }) => {
   return (
@@ -13,7 +14,7 @@ const ArticleComponent = ({ article, index }) => {
         {article.cover_image && (
           <div 
             className="w-full h-44 bg-cover bg-center border-b-2 border-black"
-            style={{ backgroundImage: `url(${article.cover_image})` }}
+            style={{ backgroundImage: `url(${assetUrl(article.cover_image)})` }}
           />
         )}
         

--- a/src/components/callout.js
+++ b/src/components/callout.js
@@ -1,0 +1,48 @@
+import React from "react";
+
+// Available inside post bodies as <Callout type="note">…</Callout> — see
+// wrapRootElement.js, which puts it in the MDXProvider components map.
+//
+// Class strings are written out in full rather than composed (`bg-${type}`):
+// Tailwind's purge scans src/**/*.js as plain text, so any class it cannot see
+// literally is stripped from the build.
+//
+// Opacity uses `bg-opacity-*`, not the `bg-accent/20` slash form. This project
+// is Tailwind 2.2 with no `mode: "jit"`, and slash-opacity is JIT-only there —
+// it compiles to nothing at all.
+const VARIANTS = {
+  note: {
+    label: "NOTE",
+    box: "bg-accent bg-opacity-30",
+    chip: "bg-accent",
+  },
+  tip: {
+    label: "TIP",
+    box: "bg-primary bg-opacity-20",
+    chip: "bg-primary",
+  },
+  warn: {
+    label: "WARNING",
+    box: "bg-amber-400 bg-opacity-20",
+    chip: "bg-amber-400",
+  },
+};
+
+const Callout = ({ type = "note", title, children }) => {
+  // An unknown type renders as a note rather than crashing the page — a
+  // Writer Agent typo shouldn't take down the whole post.
+  const variant = VARIANTS[type] || VARIANTS.note;
+
+  return (
+    <aside className={`callout border-2 border-black rounded shadow-md p-5 my-8 ${variant.box}`}>
+      <div
+        className={`inline-block font-head text-xs tracking-wider uppercase border-2 border-black rounded px-2.5 py-1 mb-3 text-black ${variant.chip}`}
+      >
+        {title || variant.label}
+      </div>
+      <div className="callout-body font-sans text-black">{children}</div>
+    </aside>
+  );
+};
+
+export default Callout;

--- a/src/styles/fix.css
+++ b/src/styles/fix.css
@@ -49,7 +49,21 @@
   font-style: italic;
 }
 
-.article-content ul, 
+/* Callout (src/components/callout.js). MDX wraps the children in <p>, which
+   picks up the 1.5rem bottom margin from the rule above — that leaves dead
+   space inside the box. Drop it on the last child only. */
+.article-content .callout-body > p:last-child {
+  margin-bottom: 0;
+}
+
+/* Images inside a callout are inline illustrations, not full-width figures,
+   so they skip the large margins and hard shadow applied further down. */
+.article-content .callout-body img {
+  margin: 1rem auto;
+  box-shadow: none;
+}
+
+.article-content ul,
 .article-content ol {
   margin-left: 1.5rem;
   margin-bottom: 1.5rem;

--- a/src/templates/postPage.js
+++ b/src/templates/postPage.js
@@ -5,6 +5,7 @@ import Footer from "../components/footer";
 import Container from "../components/container";
 import Poster from "../components/poster";
 import { datePipe } from "../utils/datePipe";
+import { assetUrl } from "../utils/assetUrl";
 
 const PostPage = ({ pageContext: { article }, data }) => {
   React.useEffect(() => {
@@ -16,9 +17,20 @@ const PostPage = ({ pageContext: { article }, data }) => {
   const TitleComponent = () => {
     return (
       <div className="bg-white border-2 border-black rounded shadow-lg max-w-2xl mx-auto mt-8 sm:mt-12 p-6 sm:p-8 z-10 relative select-none animate-float-instant">
-        <h1 className="font-head text-2xl sm:text-3xl md:text-4xl text-center leading-tight mb-4 text-black">
+        <h1
+          className={`font-head text-2xl sm:text-3xl md:text-4xl text-center leading-tight text-black ${
+            article.headline ? "mb-2" : "mb-4"
+          }`}
+        >
           {article.title}
         </h1>
+        {/* text-opacity-*, not text-black/60: this project is Tailwind 2
+            without JIT, where slash-opacity utilities generate no CSS. */}
+        {article.headline && (
+          <p className="font-sans text-base sm:text-lg text-center leading-snug mb-4 text-black text-opacity-60">
+            {article.headline}
+          </p>
+        )}
         <div className="flex items-center justify-center gap-2 text-xs sm:text-sm font-semibold text-black/60 font-sans">
           {article.status !== "published" && (
             <span className="bg-amber-400/70 border border-black/20 rounded px-2.5 py-0.5 text-black">
@@ -41,7 +53,7 @@ const PostPage = ({ pageContext: { article }, data }) => {
         {article.cover_image ? (
           <div 
             className="w-full h-full bg-cover bg-center"
-            style={{ backgroundImage: `url(${article.cover_image})` }}
+            style={{ backgroundImage: `url(${assetUrl(article.cover_image)})` }}
           />
         ) : (
           <div className="w-full h-full retro-grid" />

--- a/src/utils/assetUrl.js
+++ b/src/utils/assetUrl.js
@@ -1,0 +1,21 @@
+import { withPrefix } from "gatsby";
+
+// Absolute URL (https:, data:, mailto:) or protocol-relative (//cdn...).
+const IS_ABSOLUTE = /^([a-z][a-z0-9+.-]*:|\/\/)/i;
+
+// Resolves an image reference that may be either remote or local.
+//
+// Local assets are committed under static/ and referenced root-relative
+// ("/images/foo.png"). PR previews build with a pathPrefix
+// ("/pr-preview/pr-N/", see gatsby-config.js), so a root-relative path 404s
+// there unless it goes through withPrefix — and that is precisely where a post
+// gets reviewed before merge. Production has an empty prefix, so the bug is
+// invisible everywhere except the one place it matters.
+//
+// Remote URLs must NOT be prefixed, and most existing posts use them
+// (dev.to/Cloudinary), so the passthrough is the common case.
+export const assetUrl = (src) => {
+  if (!src) return src;
+
+  return IS_ABSOLUTE.test(src) ? src : withPrefix(src);
+};

--- a/src/wrapRootElement.js
+++ b/src/wrapRootElement.js
@@ -1,0 +1,31 @@
+import React from "react";
+import { MDXProvider } from "@mdx-js/react";
+import Callout from "./components/callout";
+import { assetUrl } from "./utils/assetUrl";
+
+// Post bodies reference local images root-relative ("/images/foo.png").
+// Routing every <img> through assetUrl makes those survive a pathPrefix build
+// (PR previews) while leaving the remote dev.to/Cloudinary URLs in the
+// existing posts untouched.
+const MdxImage = ({ src, alt, ...rest }) => (
+  <img {...rest} src={assetUrl(src)} alt={alt || ""} />
+);
+
+// Anything listed here is usable in a post body with no import statement.
+const components = {
+  Callout,
+  img: MdxImage,
+};
+
+// Lives in src/ rather than the repo root so it is unambiguously covered by
+// Gatsby's babel pipeline (JSX + ESM). Referenced from both gatsby-browser.js
+// and gatsby-ssr.js — a provider registered in only one of them renders
+// correctly in the browser and wrongly in the SSR'd HTML.
+//
+// gatsby-plugin-mdx-embed already installs its own MdxEmbedProvider via
+// wrapRootElement. @mdx-js/react v1 merges a nested provider's components with
+// the parent's, so the embed shortcodes (CodePen, YouTube, Tweet) keep working
+// alongside these.
+export const wrapRootElement = ({ element }) => (
+  <MDXProvider components={components}>{element}</MDXProvider>
+);


### PR DESCRIPTION
## What this does

Adds `mcp-server/`, an [MCP](https://modelcontextprotocol.io) server exposing the post lifecycle as typed tools so an AI agent (Claude Code, Claude Desktop, Cursor) can draft, revise and publish articles without guessing at shell commands. It's registered in `.mcp.json`, so Claude Code picks it up automatically in this repo.

| Tool | What it does |
| :--- | :--- |
| `list_posts` | Every article with slug, title, headline, status, date, tags |
| `read_post` | One article's frontmatter and MDX body |
| `create_draft` | New `.mdx` with `status: unpublished`; refuses to overwrite |
| `update_post` | Partial update of metadata and/or body |
| `publish_post` | Flip to `published` and stamp `published_at` |
| `add_asset` | Write a base64 image to `static/images/`, return its URL |
| `stage_changes` | Commit and push to the `new-articles` branch |

## One source of truth for post logic

`develop-tools/posts.js` is extracted as the single place that knows how an MDX post is shaped and mutated. `new-post.js` and `publish-post.js` are rewritten to delegate to it, so the CLI scripts and the agent can't drift apart. Each entry point takes `postsDir` rather than resolving it, which is what lets the server operate on a different checkout.

Slugs and asset filenames become paths, so both are pattern-validated and then re-checked against the resolved directory. `publishPost` keeps its existing semantics — no-op when already published, `published_at` stamped only when unset.

## Nothing here can reach the live site

Writes land in a dedicated git worktree at `.mcp-worktree/` (gitignored) on a `new-articles` branch, never your working tree — you can be mid-edit or mid-rebase while the agent works.

```
agent → new-articles → you open a PR → preview build → merge → npm run deploy
```

The branch name is hardcoded rather than a parameter, because it's the safety boundary: no workflow builds it (`pr-preview.yml` triggers on `pull_request`, not `push`), so the agent stages and a human opens the PR.

Supporting details:
- The commit pathspec is an explicit allowlist (`content/posts`, `static/images`), so an unrelated dirty file can't ride along.
- Git calls use `execFile` with array arguments throughout — a slug or commit message never reaches a shell.
- The worktree pull is `--ff-only` and failure is non-fatal; a diverged branch is left for a human rather than auto-merged.
- `new-articles` is cut from whatever the main tree has checked out (override with `MCP_BASE_BRANCH`), deliberately **not** `master` — master still predates the MDX pipeline and has no `content/posts`, so a branch based there would read as a revert. This self-corrects once this release lands.

## Rendering changes

- **`<Callout type="note|tip|warn">`** in post bodies, via an `MDXProvider` in `src/wrapRootElement.js` registered from *both* `gatsby-browser.js` and `gatsby-ssr.js` — a provider in only one renders correctly in the browser and wrongly in the SSR'd HTML. Nesting under mdx-embed's own provider is safe; `@mdx-js/react` v1 merges the component maps, so `<YouTube>`/`<CodePen>`/`<Tweet>` keep working.
- **`src/utils/assetUrl.js`** routes local image references through `withPrefix` while passing remote URLs (dev.to/Cloudinary) through untouched. Applied to every `<img>` via the provider and to `cover_image` in `postPage.js` and `articleList.js`. Without it, root-relative paths 404 under the PR preview's `pathPrefix` — the one place a post gets reviewed, and invisible in both local and production builds.
- **`headline` frontmatter** — the deck rendered under the `<h1>`, distinct from `description` (the listing blurb, not shown on the post page). Conflating the two is the default mistake for an authoring agent, so the tool descriptions and `mcp-server/README.md` call it out explicitly. Added to the `gatsby-node.js` GraphQL query.

Tailwind note: this project is Tailwind 2.2 without JIT, where slash-opacity utilities compile to nothing. The callout and headline use `bg-opacity-*` / `text-opacity-*`, and variant classes are written out in full so purge can see them.

## Notes for review

- Dependencies are isolated in `mcp-server/package.json` — the root tree is Gatsby 3 / React 17 and needs `--legacy-peer-deps`, so keeping the SDK separate avoids a resolution fight. Run `cd mcp-server && npm install` once.
- Tradeoff: because agent drafts live on `new-articles`, `npm run develop` in the repo root won't show them. Check out that branch to preview locally, or use the PR preview URL.
- `.mcp.json` intentionally contains only the `articles` server — no machine-specific paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151FcLd1Q7JiUCraQMZ9xrd
