### PR TITLE
refactor(mcp): publish on the main working tree instead of a worktree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,3 @@ target/
 prompt.md
 .gemini/
 .antigravitycli/
-
-# Git worktree the MCP publisher server writes posts into (branch: new-articles)
-.mcp-worktree/

--- a/README.md
+++ b/README.md
@@ -125,18 +125,18 @@ All tools share `develop-tools/posts.js` with the npm scripts above, so the CLI 
 
 ### Where the agent can and can't reach
 
-The agent writes to a **separate git worktree** at `.mcp-worktree/` (gitignored), checked out to a branch called `new-articles`. Two things follow from that:
+The agent works in your **main working tree**, switching it to a branch called `new-articles` on every call. Two things follow from that:
 
-- **Your working tree is never touched.** You can be mid-edit or mid-rebase on another branch while the agent works.
+- **Everything stays on `new-articles`.** The commit pathspec is an explicit allowlist (`content/posts`, `static/images`), so an unrelated dirty file can't ride along — but the switch itself moves your working tree. If uncommitted changes would block it, the call fails with an explanation instead of forcing it, so commit or stash first.
 - **Nothing the agent does can reach the live site.** No workflow builds `new-articles` — `pr-preview.yml` triggers on `pull_request`, not `push`. The agent stages; *you* open the PR, which is what triggers the preview build, and `npm run deploy` stays manual.
 
 ```
 agent → new-articles → you open a PR → preview build → merge → npm run deploy
 ```
 
-`new-articles` is branched from whatever the main working tree has checked out the first time the worktree is created (override with `MCP_BASE_BRANCH`). Note this is deliberately *not* `master` — until `release/v1.2.0` lands, master predates the MDX pipeline and has no `content/posts` at all.
+`new-articles` is branched from whatever the working tree was on before the first switch (override with `MCP_BASE_BRANCH`). Note this is deliberately *not* `master` — until `release/v1.2.0` lands, master predates the MDX pipeline and has no `content/posts` at all.
 
-One tradeoff worth knowing: because agent drafts live on `new-articles`, `npm run develop` in the repo root won't show them. Check out `new-articles` yourself to preview locally, or open the PR and use the preview URL.
+Two tradeoffs worth knowing: a publishing session **leaves your working tree checked out on `new-articles`** (files stay uncommitted there until `stage_changes`), and because agent drafts live on `new-articles`, `npm run develop` from that branch is where you preview them — or open the PR and use the preview URL.
 
 ## 👀 PR Previews
 

--- a/develop-tools/posts.js
+++ b/develop-tools/posts.js
@@ -2,8 +2,8 @@
 // created, and mutated.
 //
 // Every entry point takes `postsDir` rather than resolving it here — the CLI
-// scripts pass the repo's content/posts/, while the MCP server points at a
-// separate git worktree so it can commit without touching your working tree.
+// scripts and the MCP server both pass the repo's content/posts/; the server
+// simply switches the working tree to the new-articles branch first.
 
 const path = require("path");
 const fs = require("fs");

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -77,16 +77,21 @@ untouched. Skipping it produces images that work locally and in production but
 
 ## Where the files live
 
-None of these tools touch your working tree. The server keeps a separate git
-worktree at `.mcp-worktree/`, checked out to the `new-articles` branch. Posts
-live in `.mcp-worktree/content/posts/` and images in
-`.mcp-worktree/static/images/` (see `PATHS` in `git.js` — the commit pathspec is
-an explicit allowlist, so an unrelated dirty file can never ride along). You can
-be mid-edit on any branch and article writing won't collide with it.
+The server works directly in your main working tree. On every call it switches
+the tree to the `new-articles` branch (creating it if needed) and writes posts
+to `content/posts/` and images to `static/images/` (see `PATHS` in `git.js` —
+the commit pathspec is an explicit allowlist, so an unrelated dirty file can
+never ride along). If the tree has uncommitted changes that would block the
+switch, the call fails with an explanation instead of forcing it — commit or
+stash first.
 
-The base branch for `new-articles` is inferred from whatever branch you are
-currently on (`master` if you are already on `new-articles`), overridable with
-`MCP_BASE_BRANCH`.
+Two consequences worth knowing: a publishing session **leaves your working tree
+on `new-articles`**, and the draft files sit there uncommitted until
+`stage_changes` lands them.
+
+The base branch for `new-articles` is inferred from whatever branch the tree was
+on before the first switch (`master` if it was already on `new-articles`),
+overridable with `MCP_BASE_BRANCH`.
 
 All post logic is delegated to `develop-tools/posts.js` — the same module the npm
 scripts use, so the CLI and the agent can never drift apart.
@@ -103,8 +108,8 @@ create_draft ──► update_post (iterate) ──► publish_post ──► st
 ```
 
 1. **Draft** — `create_draft` writes the file with `status: unpublished`. It is on
-   disk in the worktree, uncommitted. `add_asset` first if the post needs local
-   images, so the returned URLs can go straight into the body.
+   disk on the `new-articles` branch, uncommitted. `add_asset` first if the post
+   needs local images, so the returned URLs can go straight into the body.
 2. **Iterate** — `read_post` / `update_post` as many times as you like. Still local,
    still uncommitted.
 3. **Publish** — `publish_post` only edits frontmatter. Nothing is live yet; this is

--- a/mcp-server/git.js
+++ b/mcp-server/git.js
@@ -1,9 +1,16 @@
 // Git plumbing for the publisher tool.
 //
-// Everything happens inside a dedicated worktree checked out to `new-articles`,
-// never the repo's main working tree. That way the agent can commit and push
-// while you're mid-edit on another branch, and it can never land a commit on
-// whatever you happen to have checked out.
+// The agent works directly in the repo's main working tree: every tool call
+// switches it to `new-articles`, writes there, and (on stage_changes) commits
+// and pushes. There is no separate worktree. The trade-off is deliberate — a
+// publishing session leaves your working tree checked out on `new-articles`,
+// and files stay there uncommitted until stage_changes lands them.
+//
+// The safety boundary is the branch, not isolation: `new-articles` is hardcoded
+// and no workflow builds it, so nothing the agent pushes reaches the public
+// site without a human opening a PR. If switching branches isn't possible
+// (uncommitted changes git would clobber), the switch fails loudly and the
+// reason is handed back to the agent rather than forced through.
 //
 // execFile (not exec) throughout: arguments are passed as an array, so a slug
 // or commit message can never reach a shell.
@@ -25,14 +32,13 @@ const { ASSETS_SUBPATH } = require("../develop-tools/posts.js");
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 
 export const REPO_ROOT = path.resolve(HERE, "..");
-export const WORKTREE = path.join(REPO_ROOT, ".mcp-worktree");
-export const POSTS_DIR = path.join(WORKTREE, "content", "posts");
-export const ASSETS_DIR = path.join(WORKTREE, ASSETS_SUBPATH);
+export const POSTS_DIR = path.join(REPO_ROOT, "content", "posts");
+export const ASSETS_DIR = path.join(REPO_ROOT, ASSETS_SUBPATH);
 
 // Everything the agent is allowed to commit, as git pathspecs (POSIX
 // separators — git does not accept backslashes here even on Windows).
 // An explicit allowlist, not a convenience: it is what keeps an unrelated
-// dirty file in the worktree out of the agent's commits.
+// dirty file in the working tree out of the agent's commits.
 const PATHS = ["content/posts", ASSETS_SUBPATH.split(path.sep).join("/")];
 
 // Hardcoded on purpose — not a parameter. This is the safety boundary: no
@@ -54,38 +60,58 @@ const branchExists = async (ref) => {
   }
 };
 
+const currentBranch = () => git(["branch", "--show-current"]);
+
 // Which branch `new-articles` is cut from, and what its pull request targets.
 //
 // NOT origin/master: as of this writing master predates the MDX content
 // pipeline (it still carries the SQLite-era gatsby-node.js and no
 // content/posts at all), so a branch based there would hold zero existing
-// posts and its PR would read as a revert. Defaulting to whatever the main
-// working tree has checked out guarantees the base has the same content
-// pipeline you're editing against, and it self-corrects once a release lands
-// on master. Override with MCP_BASE_BRANCH when that isn't what you want.
-const resolveBase = async () => {
+// posts and its PR would read as a revert. Defaulting to whatever the working
+// tree had checked out before we switched guarantees the base has the same
+// content pipeline you're editing against, and it self-corrects once a release
+// lands on master. Override with MCP_BASE_BRANCH when that isn't what you want.
+const resolveBase = (previous) => {
   if (process.env.MCP_BASE_BRANCH) return process.env.MCP_BASE_BRANCH;
 
-  const current = await git(["branch", "--show-current"]);
-
   // Detached HEAD gives an empty string; the branch can't be its own base.
-  if (!current || current === BRANCH) return "master";
+  if (!previous || previous === BRANCH) return "master";
 
-  return current;
+  return previous;
 };
 
-// Lazily prepares the worktree and returns the posts directory to operate on.
-// Safe to call on every tool invocation: each step is a no-op once satisfied.
-export const ensureWorktree = async () => {
-  if (!fs.existsSync(WORKTREE)) {
-    if (await branchExists(BRANCH)) {
-      await git(["worktree", "add", WORKTREE, BRANCH]);
-    } else {
-      const base = await resolveBase();
+// git switch, but a refusal (uncommitted changes it would overwrite) becomes a
+// clear, actionable message instead of a raw non-zero exit. The tool() wrapper
+// in index.js turns a thrown error into MCP error text the agent reads back.
+const switchBranch = async (args) => {
+  try {
+    await git(["switch", ...args]);
+  } catch (error) {
+    const detail = (error.stderr || error.message || "").trim();
+    throw new Error(
+      `Cannot switch to '${BRANCH}': ${detail}\n` +
+        "Commit or stash the changes in your working tree, then try again."
+    );
+  }
+};
 
-      await git(["worktree", "add", "-b", BRANCH, WORKTREE, base]);
-      // Remember the base so the PR link keeps pointing at it even after you
-      // switch branches in the main tree.
+// Puts the main working tree on `new-articles` and returns the directories the
+// post tools write into. Safe to call on every tool invocation: once we are
+// already on the branch it is a no-op beyond ensuring the directories exist.
+export const ensureBranch = async () => {
+  const previous = await currentBranch();
+
+  if (previous !== BRANCH) {
+    if (await branchExists(BRANCH)) {
+      await switchBranch([BRANCH]);
+    } else if (await branchExists(`origin/${BRANCH}`)) {
+      // Only on the remote — create a local tracking branch from it.
+      await switchBranch(["-c", BRANCH, `origin/${BRANCH}`]);
+    } else {
+      // Brand new — cut it from the base and remember the base so the PR link
+      // keeps pointing at it even after you switch branches later.
+      const base = resolveBase(previous);
+      await switchBranch(["-c", BRANCH, base]);
       await git(["config", "mcp.baseBranch", base]);
     }
   }
@@ -94,7 +120,7 @@ export const ensureWorktree = async () => {
   // cleanly. A diverged branch is a human's problem to resolve — never
   // rebase or merge on the agent's behalf.
   try {
-    await git(["pull", "--ff-only", "origin", BRANCH], WORKTREE);
+    await git(["pull", "--ff-only", "origin", BRANCH]);
   } catch {
     // No upstream yet, or it diverged. Either way, keep going: the commit
     // succeeds locally and `push` below will surface a real conflict.
@@ -107,16 +133,13 @@ export const ensureWorktree = async () => {
 };
 
 export const pendingChanges = async () => {
-  const status = await git(
-    ["status", "--porcelain", "--", ...PATHS],
-    WORKTREE
-  );
+  const status = await git(["status", "--porcelain", "--", ...PATHS]);
 
   return status ? status.split("\n").map((line) => line.trim()) : [];
 };
 
 // Commits and pushes only the PATHS allowlist. The pathspec means that even if
-// something else in the worktree is dirty, it stays out of the commit.
+// something else in the working tree is dirty, it stays out of the commit.
 export const commitAndPush = async (message) => {
   const changes = await pendingChanges();
 
@@ -124,11 +147,11 @@ export const commitAndPush = async (message) => {
     return { pushed: false, reason: `No changes under ${PATHS.join(", ")} to commit.` };
   }
 
-  await git(["add", "--", ...PATHS], WORKTREE);
-  await git(["commit", "-m", message, "--", ...PATHS], WORKTREE);
-  await git(["push", "--set-upstream", "origin", BRANCH], WORKTREE);
+  await git(["add", "--", ...PATHS]);
+  await git(["commit", "-m", message, "--", ...PATHS]);
+  await git(["push", "--set-upstream", "origin", BRANCH]);
 
-  const sha = await git(["rev-parse", "--short", "HEAD"], WORKTREE);
+  const sha = await git(["rev-parse", "--short", "HEAD"]);
   const remote = await git(["remote", "get-url", "origin"]);
   const repo = remote
     .replace(/^git@github\.com:/, "")
@@ -139,7 +162,7 @@ export const commitAndPush = async (message) => {
   try {
     base = await git(["config", "--get", "mcp.baseBranch"]);
   } catch {
-    // Worktree predates the config, or it was cleared. `master` is a safe
+    // Branch predates the config, or it was cleared. `master` is a safe
     // fallback for a link — the PR target is editable in GitHub's UI anyway.
   }
 

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -6,14 +6,15 @@
 //
 // All post logic is delegated to develop-tools/posts.js — the same module the
 // npm scripts use, so the CLI and the agent can never drift apart. Writes land
-// in a git worktree on `new-articles` (see git.js), never your working tree.
+// on the `new-articles` branch in your working tree (see git.js), which the
+// server switches to on every call.
 
 import { createRequire } from "node:module";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 
-import { ensureWorktree, commitAndPush, pendingChanges, BRANCH } from "./git.js";
+import { ensureBranch, commitAndPush, pendingChanges, BRANCH } from "./git.js";
 
 // posts.js is CommonJS; createRequire is the unambiguous way to load it from ESM.
 const require = createRequire(import.meta.url);
@@ -34,8 +35,8 @@ const COVER_IMAGE_HINT =
 // read and correct. Wrapping here keeps every handler free of try/catch.
 const tool = (handler) => async (args) => {
   try {
-    // { postsDir, assetsDir } — both live inside the worktree.
-    const dirs = await ensureWorktree();
+    // { postsDir, assetsDir } — both under the repo root on the new-articles branch.
+    const dirs = await ensureBranch();
     const result = await handler(args, dirs);
 
     return {


### PR DESCRIPTION
## What

The MCP publisher server no longer uses a separate `.mcp-worktree` checkout. Each tool call now switches the **main working tree** to `new-articles`, writes there, and stages from the repo root.

## Why

Simplifies the publishing model to a single working tree. There is no second checkout to keep in sync or clean up.

## Behavior

- On every call the server switches the working tree to `new-articles` (creating it from the base branch if it doesn't exist).
- **If the switch isn't possible** (uncommitted changes git would clobber), the call fails with a clear explanation instead of forcing it — commit or stash first.
- `stage_changes` commits the `content/posts` + `static/images` allowlist and pushes, returning a compare URL.

## Trade-offs (documented in the READMEs)

- A publishing session **leaves your working tree checked out on `new-articles`**.
- Draft files stay uncommitted on that branch until `stage_changes` lands them.

## Safety boundary — unchanged

- `new-articles` is still hardcoded; no workflow builds it, so nothing reaches the live site without a human-opened PR.
- The commit pathspec allowlist still keeps unrelated dirty files out of commits.

## Files

- `mcp-server/git.js` — rewritten: `ensureWorktree` → `ensureBranch`, switch-in-place, explain-on-failure.
- `mcp-server/index.js` — updated import, comments.
- `develop-tools/posts.js`, `mcp-server/README.md`, `README.md` — docs.
- `.gitignore` — dropped the `.mcp-worktree/` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)