### PR TITLE
feat: add reader controls and serif article typography

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -17,7 +17,7 @@ const HeadComponents = [
   />,
   <link
     key="3"
-    href="https://fonts.googleapis.com/css2?family=Archivo+Black&family=Space+Grotesk:wght@300..700&display=swap"
+    href="https://fonts.googleapis.com/css2?family=Archivo+Black&family=Bentham&family=Domine:wght@400..700&family=Space+Grotesk:wght@300..700&display=swap"
     rel="stylesheet"
   ></link>,
   <script

--- a/src/components/callout.js
+++ b/src/components/callout.js
@@ -40,7 +40,7 @@ const Callout = ({ type = "note", title, children }) => {
       >
         {title || variant.label}
       </div>
-      <div className="callout-body font-sans text-black">{children}</div>
+      <div className="callout-body font-bentham text-black">{children}</div>
     </aside>
   );
 };

--- a/src/components/poster.js
+++ b/src/components/poster.js
@@ -24,7 +24,10 @@ const glitchOffIcons = ["❌", "🔕", "🚫", "💤", "⛔", "🔇", "🙈", "�
 const loadingIcons   = ["⏳", "⌛", "🔄", "💫"];
 const pick = (arr) => arr[Math.floor(Math.random() * arr.length)];
 
-const Poster = ({ colorOpacity = 0.7 }) => {
+// `extraControls` lets a page drop a page-specific button into the fixed
+// bottom-left control row (postPage passes its share button), so those buttons
+// line up with the poster/glitch pair instead of needing their own fixed box.
+const Poster = ({ colorOpacity = 0.7, extraControls = null }) => {
   const [currentPosterIndex, setCurrentPosterIndex] = useState(0);
   const [currentColorIndex, setCurrentColorIndex] = useState(0);
   const [isTransitioning, setIsTransitioning] = useState(false);
@@ -116,11 +119,11 @@ const Poster = ({ colorOpacity = 0.7 }) => {
   return (
     <>
       {/* Floating Retro Controls (Change Poster + Glitch Toggle Buttons) */}
-      <div className="fixed bottom-6 left-6 z-50 flex items-center space-x-3 animate-brutalist-wiggle">
+      <div className="fixed bottom-6 left-6 z-50 flex items-center space-x-2 animate-brutalist-wiggle">
         <button 
           onClick={changePoster}
           disabled={isTransitioning}
-          className="font-head text-xl bg-primary text-black border-2 border-black rounded w-11 h-11 flex items-center justify-center shadow-md hover:shadow-none hover:translate-x-0.5 hover:translate-y-0.5 active:translate-x-1 active:translate-y-1 active:shadow-xs transition-all duration-150 cursor-pointer select-none disabled:opacity-75 disabled:cursor-not-allowed"
+          className="font-head text-xs bg-primary text-black border-2 border-black rounded w-control h-control flex items-center justify-center shadow-sm hover:shadow-none hover:translate-x-0.5 hover:translate-y-0.5 active:translate-x-1 active:translate-y-1 active:shadow-xs transition-all duration-150 cursor-pointer select-none disabled:opacity-75 disabled:cursor-not-allowed"
           title="Switch background video and color theme"
         >
           {isTransitioning ? icons.loading : icons.poster}
@@ -128,7 +131,7 @@ const Poster = ({ colorOpacity = 0.7 }) => {
 
         <button 
           onClick={toggleGlitch}
-          className={`font-head text-xl border-2 border-black rounded w-11 h-11 flex items-center justify-center shadow-md hover:shadow-none hover:translate-x-0.5 hover:translate-y-0.5 active:translate-x-1 active:translate-y-1 transition-all duration-150 cursor-pointer select-none ${
+          className={`font-head text-xs border-2 border-black rounded w-control h-control flex items-center justify-center shadow-sm hover:shadow-none hover:translate-x-0.5 hover:translate-y-0.5 active:translate-x-1 active:translate-y-1 transition-all duration-150 cursor-pointer select-none ${
             glitchEnabled 
               ? "bg-accent text-black" 
               : "bg-red-500 text-white"
@@ -137,6 +140,8 @@ const Poster = ({ colorOpacity = 0.7 }) => {
         >
           {glitchEnabled ? icons.glitchOn : icons.glitchOff}
         </button>
+
+        {extraControls}
       </div>
 
       {/* Fullscreen Video Background & Dual Overlay (Color + Dark) */}

--- a/src/styles/fix.css
+++ b/src/styles/fix.css
@@ -1,14 +1,55 @@
 /* Markdown / Dev.to Article Styling Overrides */
 
+/* Body size and leading come from custom properties so the reader controls in
+   postPage.js can retune the whole article by swapping one class on the
+   wrapper, instead of every rule below needing a variant.
+   2.1 is the previous 1.75 plus 20%. Domine tops out at 700, so that is its
+   heaviest weight — `font-weight: 800` here would silently synthesize. */
 .article-content {
-  font-family: 'Space Grotesk', sans-serif;
+  --article-font-size: 1.125rem;
+  --article-line-height: 2.1;
+  font-family: 'Domine', serif;
+  font-weight: 700;
   color: #000000;
-  line-height: 1.75;
+  font-size: var(--article-font-size);
+  line-height: var(--article-line-height);
 }
+
+/* Reader control: text size. The -m values match the defaults above. */
+.article-content.article-size-s { --article-font-size: 1rem; }
+.article-content.article-size-m { --article-font-size: 1.125rem; }
+.article-content.article-size-l { --article-font-size: 1.375rem; }
+
+/* Reader control: line spacing. */
+.article-content.article-leading-s { --article-line-height: 1.6; }
+.article-content.article-leading-m { --article-line-height: 2.1; }
+.article-content.article-leading-l { --article-line-height: 2.6; }
 
 .article-content p {
   margin-bottom: 1.5rem;
-  font-size: 1.125rem;
+  font-size: var(--article-font-size);
+}
+
+/* The figure owns the vertical rhythm, so the image inside it drops the 2.5rem
+   margins it gets further down — otherwise the caption floats a block away
+   from the image it describes. */
+.article-content figure {
+  margin: 2.5rem 0;
+}
+
+.article-content figure img {
+  margin: 0 auto;
+}
+
+/* Captions are an aside to the figure, not body copy: smaller, lighter and set
+   tight so they read as a label rather than a paragraph. */
+.article-content figcaption {
+  font-size: 0.8125rem;
+  font-weight: 400;
+  line-height: 1.5;
+  text-align: center;
+  color: #5a5a5a;
+  margin-top: 0.75rem;
 }
 
 .article-content h1, 
@@ -56,6 +97,17 @@
   margin-bottom: 0;
 }
 
+/* Callouts are the pull-quote moment of a post: Bentham, set larger than the
+   surrounding Domine body. The `p` selector is needed because MDX wraps the
+   children, and `.article-content p` would otherwise win on font-size. */
+.article-content .callout-body,
+.article-content .callout-body p {
+  font-family: 'Bentham', serif;
+  font-weight: 400;
+  font-size: calc(var(--article-font-size) * 1.33);
+  line-height: 1.5;
+}
+
 /* Images inside a callout are inline illustrations, not full-width figures,
    so they skip the large margins and hard shadow applied further down. */
 .article-content .callout-body img {
@@ -89,6 +141,94 @@
   max-width: 100%;
   height: auto;
   display: block;
+}
+
+/* ---------- Article dark theme (reader control in postPage.js) ----------
+   Scoped to the two `.article-box` containers only — the poster background,
+   tag chips, footer and back link stay as they are. Every selector doubles up
+   (`.article-box.article-dark`) to outrank the single-class Tailwind utilities
+   it overrides, rather than relying on stylesheet order. */
+.article-box.article-dark {
+  background-color: #14110f;
+  border-color: #f5ece7;
+  color: #f5ece7;
+}
+
+.article-box.article-dark .article-content,
+.article-box.article-dark h1,
+.article-box.article-dark h2,
+.article-box.article-dark h3,
+.article-box.article-dark h4 {
+  color: #f5ece7;
+}
+
+.article-box.article-dark .article-headline {
+  color: #cfc6c1;
+}
+
+/* h2's underline and the figure/cover borders are hard black by default, which
+   vanishes against the dark panel. */
+.article-box.article-dark .article-content h2 {
+  border-bottom-color: #f5ece7;
+}
+
+.article-box.article-dark img {
+  border-color: #f5ece7;
+}
+
+.article-box.article-dark .article-content img {
+  box-shadow: 6px 6px 0 0 #f5ece7;
+}
+
+.article-box.article-dark .article-content .callout-body img {
+  box-shadow: none;
+}
+
+.article-box.article-dark .article-content figcaption {
+  color: #9c938e;
+}
+
+/* Links keep the yellow highlight, so their text has to stay black. */
+.article-box.article-dark .article-content a {
+  color: #000000;
+}
+
+/* Callouts. In light mode the box is its accent colour at 20–30% over white, a
+   pale tint that black body text sits on happily. Over the dark panel that same
+   tint composites to a muddy olive, and callout.js puts `text-black` straight on
+   .callout-body — a declaration on the element itself, so it beats the light
+   colour the rest of the body inherits. Result is black on dark. Thin the wash
+   out and flip the text; the chip stays solid and keeps carrying the variant
+   colour, because `bg-accent` and friends re-declare --tw-bg-opacity locally. */
+.article-box.article-dark .article-content .callout {
+  --tw-bg-opacity: 0.14;
+  border-color: #f5ece7;
+  box-shadow: 4px 4px 0 0 #f5ece7;
+}
+
+.article-box.article-dark .article-content .callout-body {
+  color: #f5ece7;
+}
+
+.article-box.article-dark .article-content blockquote {
+  background-color: #14110f;
+  border-color: #f5ece7;
+  box-shadow: 4px 4px 0 0 #f5ece7;
+}
+
+.article-box.article-dark .article-content code {
+  background-color: #14110f;
+  border-color: #f5ece7;
+  color: #f5ece7;
+}
+
+.article-box.article-dark .article-content pre {
+  border-color: #f5ece7;
+  box-shadow: 4px 4px 0 0 #f5ece7;
+}
+
+.article-box.article-dark .article-content pre code {
+  color: inherit;
 }
 
 /* Code & Highlight Custom Styling */

--- a/src/templates/postPage.js
+++ b/src/templates/postPage.js
@@ -1,100 +1,292 @@
 import React from "react";
 import { Link, graphql } from "gatsby";
 import { MDXRenderer } from "gatsby-plugin-mdx";
+import { ShareIcon, CheckIcon, MoonIcon, SunIcon } from "@heroicons/react/outline";
 import Footer from "../components/footer";
 import Container from "../components/container";
 import Poster from "../components/poster";
 import { datePipe } from "../utils/datePipe";
 import { assetUrl } from "../utils/assetUrl";
 
+// Reader preferences. Index 1 is the design default baked into fix.css; the
+// other two step down and up from it. Class names are written out in full
+// (never `article-size-${n}`) so Tailwind's plain-text purge scan can see them.
+const FONT_SIZES = [
+  { className: "article-size-s", label: "Small", glyph: "text-tiny" },
+  { className: "article-size-m", label: "Medium", glyph: "text-xs" },
+  { className: "article-size-l", label: "Large", glyph: "text-sm" },
+];
+
+const LINE_HEIGHTS = [
+  { className: "article-leading-s", label: "Tight", gap: "1px" },
+  { className: "article-leading-m", label: "Normal", gap: "2px" },
+  { className: "article-leading-l", label: "Loose", gap: "3px" },
+];
+
+const STORAGE_KEYS = {
+  fontSize: "articleFontSize",
+  lineHeight: "articleLineHeight",
+  theme: "articleTheme",
+};
+
+// Matches the poster/glitch buttons in Poster's fixed row so the whole strip
+// reads as one control cluster.
+const CONTROL_BUTTON =
+  "border-2 border-black rounded w-control h-control flex items-center justify-center shadow-sm hover:shadow-none hover:translate-x-0.5 hover:translate-y-0.5 active:translate-x-1 active:translate-y-1 active:shadow-xs transition-all duration-150 cursor-pointer select-none";
+
+// Three stacked bars whose spacing tracks the current setting — the control
+// shows what it does, which no icon in the set manages.
+const LineHeightGlyph = ({ gap }) => (
+  <span className="flex flex-col w-3" style={{ rowGap: gap }}>
+    <span className="block h-px w-full bg-current" />
+    <span className="block h-px w-full bg-current" />
+    <span className="block h-px w-full bg-current" />
+  </span>
+);
+
+const ShareButton = () => {
+  const [copied, setCopied] = React.useState(false);
+
+  // navigator.clipboard is undefined on insecure origins (plain-http LAN
+  // previews), so fall back to the old execCommand dance rather than
+  // throwing and leaving the button looking dead.
+  const copyUrl = async () => {
+    const url = window.location.href;
+    try {
+      if (navigator.clipboard) {
+        await navigator.clipboard.writeText(url);
+      } else {
+        const input = document.createElement("input");
+        input.value = url;
+        document.body.appendChild(input);
+        input.select();
+        document.execCommand("copy");
+        document.body.removeChild(input);
+      }
+      setCopied(true);
+    } catch (error) {
+      setCopied(false);
+    }
+  };
+
+  React.useEffect(() => {
+    if (!copied) return undefined;
+    const timer = setTimeout(() => setCopied(false), 2000);
+    return () => clearTimeout(timer);
+  }, [copied]);
+
+  return (
+    <button
+      type="button"
+      onClick={copyUrl}
+      aria-label="Copy article link to clipboard"
+      title={copied ? "Link copied to clipboard" : "Copy article link to clipboard"}
+      className={`${CONTROL_BUTTON} ${copied ? "bg-accent text-black" : "bg-white text-black"}`}
+    >
+      {copied ? <CheckIcon className="w-3 h-3" /> : <ShareIcon className="w-3 h-3" />}
+    </button>
+  );
+};
+
+// The reading controls live in Poster's fixed row but drive classes on the
+// article boxes, so the state sits in PostPage and arrives here as props.
+const ReaderControls = ({
+  fontSize,
+  onCycleFontSize,
+  lineHeight,
+  onCycleLineHeight,
+  isDark,
+  onToggleTheme,
+}) => (
+  <>
+    <ShareButton />
+
+    <button
+      type="button"
+      onClick={onCycleFontSize}
+      aria-label={`Text size: ${FONT_SIZES[fontSize].label}. Click to cycle.`}
+      title={`Text size: ${FONT_SIZES[fontSize].label}`}
+      className={`${CONTROL_BUTTON} bg-white text-black font-head leading-none`}
+    >
+      <span className={FONT_SIZES[fontSize].glyph}>A</span>
+    </button>
+
+    <button
+      type="button"
+      onClick={onCycleLineHeight}
+      aria-label={`Line spacing: ${LINE_HEIGHTS[lineHeight].label}. Click to cycle.`}
+      title={`Line spacing: ${LINE_HEIGHTS[lineHeight].label}`}
+      className={`${CONTROL_BUTTON} bg-white text-black`}
+    >
+      <LineHeightGlyph gap={LINE_HEIGHTS[lineHeight].gap} />
+    </button>
+
+    <button
+      type="button"
+      onClick={onToggleTheme}
+      aria-label={isDark ? "Switch article to light theme" : "Switch article to dark theme"}
+      title={isDark ? "Article theme: dark" : "Article theme: light"}
+      className={`${CONTROL_BUTTON} ${isDark ? "bg-black text-white" : "bg-white text-black"}`}
+    >
+      {isDark ? <SunIcon className="w-3 h-3" /> : <MoonIcon className="w-3 h-3" />}
+    </button>
+  </>
+);
+
+// Declared at module scope rather than inside PostPage: PostPage now re-renders
+// on every reader-control click, and a component type re-created each render is
+// a different type to React — the whole box would unmount and remount,
+// re-fetching the cover image on every click.
+const ArticleTitle = ({ article, boxClass }) => (
+  <div
+    className={`article-box ${boxClass} border-2 border-black rounded shadow-lg max-w-2xl mx-auto mt-8 sm:mt-12 p-6 sm:p-8 z-10 relative select-none animate-float-instant`}
+  >
+    <h1
+      className={`font-sans font-bold text-3xl sm:text-4xl md:text-5xl text-center leading-tight ${
+        article.headline ? "mb-3" : "mb-4"
+      }`}
+    >
+      {article.title}
+    </h1>
+    {/* text-opacity-*, not text-black/60: this project is Tailwind 2
+        without JIT, where slash-opacity utilities generate no CSS. */}
+    {article.headline && (
+      <p className="article-headline font-domine font-bold text-base sm:text-lg text-center leading-snug mb-4 text-black text-opacity-60">
+        {article.headline}
+      </p>
+    )}
+    {article.cover_image && (
+      <img
+        src={assetUrl(article.cover_image)}
+        alt={article.title}
+        className="w-full border-2 border-black rounded mb-4"
+      />
+    )}
+    <div className="flex flex-wrap items-center justify-center gap-2 text-xs sm:text-sm font-domine font-bold">
+      {article.status !== "published" && (
+        <span className="bg-amber-400 bg-opacity-70 border border-black border-opacity-20 rounded px-2.5 py-0.5 text-black">
+          DRAFT
+        </span>
+      )}
+      {article.published_at && (
+        <span className="bg-primary bg-opacity-20 border border-black border-opacity-20 rounded px-2.5 py-0.5">
+          Published: {datePipe(article.published_at)}
+        </span>
+      )}
+    </div>
+  </div>
+);
+
+const ArticleTags = ({ article }) => (
+  <div className="flex flex-wrap justify-center gap-2 mt-8 max-w-2xl mx-auto select-none">
+    {article.tags &&
+      article.tags.map((tag) => (
+        <span
+          key={tag}
+          className="border-2 border-black bg-accent text-black text-xs font-domine font-bold px-2.5 py-1 rounded shadow-xs"
+        >
+          #{tag}
+        </span>
+      ))}
+  </div>
+);
+
 const PostPage = ({ pageContext: { article }, data }) => {
+  const [fontSize, setFontSize] = React.useState(1);
+  const [lineHeight, setLineHeight] = React.useState(1);
+  const [isDark, setIsDark] = React.useState(false);
+
   React.useEffect(() => {
     if (typeof window !== "undefined") {
       sessionStorage.setItem("fromPost", "true");
     }
   }, []);
 
-  const TitleComponent = () => {
-    return (
-      <div className="bg-white border-2 border-black rounded shadow-lg max-w-2xl mx-auto mt-8 sm:mt-12 p-6 sm:p-8 z-10 relative select-none animate-float-instant">
-        <h1
-          className={`font-head text-2xl sm:text-3xl md:text-4xl text-center leading-tight text-black ${
-            article.headline ? "mb-2" : "mb-4"
-          }`}
-        >
-          {article.title}
-        </h1>
-        {/* text-opacity-*, not text-black/60: this project is Tailwind 2
-            without JIT, where slash-opacity utilities generate no CSS. */}
-        {article.headline && (
-          <p className="font-sans text-base sm:text-lg text-center leading-snug mb-4 text-black text-opacity-60">
-            {article.headline}
-          </p>
-        )}
-        <div className="flex items-center justify-center gap-2 text-xs sm:text-sm font-semibold text-black/60 font-sans">
-          {article.status !== "published" && (
-            <span className="bg-amber-400/70 border border-black/20 rounded px-2.5 py-0.5 text-black">
-              DRAFT
-            </span>
-          )}
-          {article.published_at && (
-            <span className="bg-primary/20 border border-black/20 rounded px-2.5 py-0.5">
-              Published: {datePipe(article.published_at)}
-            </span>
-          )}
-        </div>
-      </div>
-    );
+  // Stored preferences are read after mount, not in the useState initializer:
+  // the server renders the defaults, so seeding state from localStorage would
+  // make the first client render disagree with the SSR'd HTML.
+  React.useEffect(() => {
+    if (typeof window === "undefined") return;
+    // Read as a string and index-check before converting: `Number(null)` is 0,
+    // so a missing key would otherwise look like a stored "Small".
+    const readIndex = (key, options) => {
+      const raw = localStorage.getItem(key);
+      if (raw === null) return null;
+      const index = Number(raw);
+      return options[index] ? index : null;
+    };
+
+    const storedFontSize = readIndex(STORAGE_KEYS.fontSize, FONT_SIZES);
+    const storedLineHeight = readIndex(STORAGE_KEYS.lineHeight, LINE_HEIGHTS);
+    if (storedFontSize !== null) setFontSize(storedFontSize);
+    if (storedLineHeight !== null) setLineHeight(storedLineHeight);
+    setIsDark(localStorage.getItem(STORAGE_KEYS.theme) === "dark");
+  }, []);
+
+  const persist = (key, value) => {
+    if (typeof window !== "undefined") {
+      localStorage.setItem(key, String(value));
+    }
   };
 
-  const BannerComponent = () => {
-    return (
-      <div className="relative w-full h-[30vh] sm:h-[40vh] border-b-2 border-black overflow-hidden bg-accent/10">
-        {article.cover_image ? (
-          <div 
-            className="w-full h-full bg-cover bg-center"
-            style={{ backgroundImage: `url(${assetUrl(article.cover_image)})` }}
-          />
-        ) : (
-          <div className="w-full h-full retro-grid" />
-        )}
-      </div>
-    );
+  const cycleFontSize = () => {
+    const next = (fontSize + 1) % FONT_SIZES.length;
+    setFontSize(next);
+    persist(STORAGE_KEYS.fontSize, next);
   };
 
-  const TagsComponent = () => {
-    return (
-      <div className="flex flex-wrap justify-center gap-2 mt-8 max-w-2xl mx-auto select-none">
-        {article.tags && article.tags.map((tag) => (
-          <span 
-            key={tag} 
-            className="border-2 border-black bg-accent text-black text-xs font-semibold px-2.5 py-1 rounded shadow-xs"
-          >
-            #{tag}
-          </span>
-        ))}
-      </div>
-    );
+  const cycleLineHeight = () => {
+    const next = (lineHeight + 1) % LINE_HEIGHTS.length;
+    setLineHeight(next);
+    persist(STORAGE_KEYS.lineHeight, next);
   };
+
+  const toggleTheme = () => {
+    const next = !isDark;
+    setIsDark(next);
+    persist(STORAGE_KEYS.theme, next ? "dark" : "light");
+  };
+
+  const boxClass = isDark ? "article-dark" : "bg-white text-black";
 
   return (
     <>
-      <Poster colorOpacity={0.8} />
-      <BannerComponent />
+      <Poster
+        colorOpacity={0.8}
+        extraControls={
+          <ReaderControls
+            fontSize={fontSize}
+            onCycleFontSize={cycleFontSize}
+            lineHeight={lineHeight}
+            onCycleLineHeight={cycleLineHeight}
+            isDark={isDark}
+            onToggleTheme={toggleTheme}
+          />
+        }
+      />
       <Container className="bg-transparent">
-        <TitleComponent />
-        <TagsComponent />
-        
+        <ArticleTitle article={article} boxClass={boxClass} />
+        <ArticleTags article={article} />
+
         {/* Main Article Content Container */}
-        <article className="max-w-3xl mx-auto px-6 sm:px-8 py-12 bg-white border-2 border-black rounded shadow-md mt-12">
-          <div className="article-content">
+        {/* Full-bleed on mobile: -mx-6 cancels the px-6 that Container puts on
+            its inner wrapper, so the box meets both screen edges and no page
+            background shows beside it. The side borders, rounding and the hard
+            shadow come off with it — a 4px offset shadow at the viewport edge
+            would also push a horizontal scrollbar. sm: restores all of it. */}
+        <article
+          className={`article-box ${boxClass} max-w-3xl -mx-6 sm:mx-auto px-10 sm:px-20 md:px-28 py-12 border-2 border-l-0 border-r-0 sm:border-l-2 sm:border-r-2 border-black rounded-none sm:rounded shadow-none sm:shadow-md mt-12`}
+        >
+          <div
+            className={`article-content ${FONT_SIZES[fontSize].className} ${LINE_HEIGHTS[lineHeight].className}`}
+          >
             <MDXRenderer>{data.mdx.body}</MDXRenderer>
           </div>
         </article>
 
         {/* Back Link Component */}
         <div className="max-w-3xl mx-auto px-4 mt-8 flex justify-start select-none">
-          <Link 
+          <Link
             to="/"
             state={{ fromPost: true }}
             className="font-head text-sm bg-white text-black border-2 border-black rounded px-4 py-2 shadow-md hover:shadow-none hover:translate-x-0.5 hover:translate-y-0.5 transition-all inline-flex items-center space-x-2"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,6 +7,11 @@ module.exports = {
     fontFamily: {
       head: ['"Archivo Black"', 'sans-serif'],
       sans: ['"Space Grotesk"', 'sans-serif'],
+      // Article typography: Bentham for titles/callouts, Domine for
+      // everything that carries the reading weight. Domine tops out at 700,
+      // so `font-bold` is its heaviest.
+      bentham: ['Bentham', 'serif'],
+      domine: ['Domine', 'serif'],
     },
     extend: {
       fontSize: {
@@ -19,6 +24,11 @@ module.exports = {
       height: {
         '40vh': '40vh',
         '60vh': '60vh',
+      },
+      spacing: {
+        // 60% of the 2.75rem the fixed control buttons used to be. A named key
+        // rather than '6.6' so the generated class needs no dot-escaping.
+        control: '1.65rem',
       },
       colors: {
         background: '#F5ECE7',


### PR DESCRIPTION
Closes #53

## Summary

Turns the post page into a proper reading surface: a serif typographic system for article body copy, plus per-reader controls for text size, line spacing and an article-scoped dark theme that persist across visits.

## Typography

- Load **Bentham** and **Domine** in `gatsby-ssr.js`; register `font-bentham` / `font-domine` in `tailwind.config.js`. Domine tops out at 700, so `font-bold` is its heaviest weight — an `800` would silently synthesize.
- `.article-content` moves from Space Grotesk to Domine. Callouts switch to Bentham at 1.33× body size so they read as the pull-quote moment of a post.
- New `figure` / `figcaption` rules so captions sit tight under their image instead of inheriting the 2.5rem image margins.

## Reader controls

- Body size and leading now come from CSS custom properties on `.article-content`, so one class swap on the wrapper retunes every rule below it (`article-size-*`, `article-leading-*`). Class names are written out in full so Tailwind 2's plain-text purge scan can see them.
- `postPage.js` gains four buttons: copy link, text size, line spacing, article dark mode. Choices persist to `localStorage`.
- Stored preferences are read in a post-mount `useEffect`, not in the `useState` initializer — seeding from `localStorage` would make the first client render disagree with the SSR'd HTML.
- The share button falls back to `document.execCommand("copy")` where `navigator.clipboard` is undefined (plain-http LAN previews).
- `Poster` takes an `extraControls` slot so these buttons join the existing fixed bottom-left row rather than opening a second floating box. All control buttons share `w-control`/`h-control` (1.65rem).

## Article dark theme

- `.article-box.article-dark` in `fix.css`, scoped to the two article containers only — poster background, tag chips, footer and back link are untouched. Every selector doubles up on the class to outrank the single-class Tailwind utilities it overrides, rather than relying on stylesheet order.
- Callouts get special handling: their light-mode tint composites to a muddy olive over the dark panel, and `callout.js` puts `text-black` directly on `.callout-body`, which beats the inherited light colour. The wash is thinned and the text flipped; the label chip stays solid and keeps carrying its variant colour.

## Layout

- The separate cover banner is gone; the cover image now sits inside the title box, above the headline and date chips.
- The article box is full-bleed on mobile (`-mx-6` cancels the padding `Container` puts on its inner wrapper) and drops its side borders, rounding and offset shadow there — a 4px offset shadow at the viewport edge would also push a horizontal scrollbar. `sm:` restores all of it.
- `ArticleTitle` and `ArticleTags` move to module scope. `PostPage` now re-renders on every control click, and a component type re-created each render is a different type to React — the box would unmount and remount, re-fetching the cover image on every click.

## Test plan

- [ ] Cycle text size and line spacing; confirm body, callouts and captions all scale together
- [ ] Reload the page and a second post — preferences carry over
- [ ] Toggle dark mode and check callouts, blockquotes, code blocks, inline code, figcaptions and links
- [ ] Copy link over https and over a plain-http LAN preview
- [ ] Mobile: article box meets both screen edges, no horizontal scrollbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wb3UhkADRrFzgPR6hdUpcP

