### PR TITLE
feat(seo): add meta tags, canonical URLs, sitemap and structured data

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -10,10 +10,61 @@
 // "pr-preview/pr-1" and Gatsby resolves it to "/pr-preview/pr-1".
 const pathPrefix = process.env.PATH_PREFIX || "";
 
+// The canonical origin. Every SEO tag is built from this, never from
+// window.location, so the URL a crawler is told about is the same whether the
+// page was server-rendered, hydrated, or built for a PR preview.
+const siteUrl = "https://thiagocolen.github.io";
+
 module.exports = {
   pathPrefix,
+  siteMetadata: {
+    siteUrl,
+    // pathPrefix is repeated here because siteMetadata is what reaches the
+    // browser bundle (via GraphQL); process.env.PATH_PREFIX is build-time only
+    // and would be undefined during hydration, desyncing the rendered tags.
+    pathPrefix,
+    // Truthy only in PR preview builds, which share the production domain
+    // (thiagocolen.github.io/pr-preview/pr-N/) and would otherwise be indexed
+    // as duplicates of the real site. Drives the noindex tag in <Seo>.
+    isPreview: Boolean(pathPrefix),
+    title: "Thiago Colen",
+    titleTemplate: "%s — Thiago Colen",
+    description:
+      "Essays on algorithms, system design, and the strange places where simple rules produce complex behaviour, by Thiago Colen.",
+    author: "Thiago Colen",
+    // Fallback share image for pages that have no cover of their own. Left
+    // empty deliberately: pointing at a file that does not exist produces a
+    // broken preview card, which is worse than no card. Drop a 1200x630 image
+    // at static/images/og-default.jpg and set this to "/images/og-default.jpg".
+    defaultImage: "",
+    social: {
+      github: "https://github.com/thiagocolen",
+      linkedin: "https://www.linkedin.com/in/thiagocolen/",
+      devto: "https://dev.to/thiagocolen",
+    },
+  },
   plugins: [
     "gatsby-plugin-postcss",
+    "gatsby-plugin-react-helmet",
+    {
+      resolve: "gatsby-plugin-sitemap",
+      options: {
+        // /homepage/ is a superseded splash variant of /, and the 404 is not a
+        // real destination — listing either invites duplicate-content and
+        // soft-404 warnings in Search Console. /about/ is a stub and carries a
+        // matching noindex in aboutPage.js; submitting a URL you also tell
+        // crawlers to ignore is a contradiction Search Console reports. Drop
+        // it from both places once the page has real content.
+        // `excludes`, not `exclude` — renamed in gatsby-plugin-sitemap v4.
+        excludes: [
+          "/homepage/",
+          "/about/",
+          "/404/",
+          "/404.html",
+          "/dev-404-page/",
+        ],
+      },
+    },
     {
       resolve: "gatsby-plugin-react-svg",
       options: {

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -5,7 +5,10 @@ const React = require("react");
 // `exports.` below), hence require rather than import.
 exports.wrapRootElement = require("./src/wrapRootElement").wrapRootElement;
 
-const HtmlAttributes = {};
+// The document had no lang, so screen readers and search engines had to guess
+// the content language. Set globally here rather than per page — it is the
+// same for the whole site.
+const HtmlAttributes = { lang: "en" };
 
 const HeadComponents = [
   <link key="1" rel="preconnect" href="https://fonts.googleapis.com" />,

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,10 @@
         "gatsby-plugin-mdx": "^2.14.0",
         "gatsby-plugin-mdx-embed": "0.0.20-alpha",
         "gatsby-plugin-page-creator": "^3.14.0",
+        "gatsby-plugin-react-helmet": "^4.15.0",
         "gatsby-plugin-react-svg": "^3.1.0",
         "gatsby-plugin-sharp": "^3.14.0",
+        "gatsby-plugin-sitemap": "^4.11.0",
         "gatsby-remark-codepen": "^0.1.1",
         "gatsby-source-filesystem": "^3.14.0",
         "gatsby-transformer-remark": "^4.11.0",
@@ -27,6 +29,7 @@
         "postcss-import": "^14.0.2",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
+        "react-helmet": "^6.1.0",
         "react-html-parser": "^2.0.2",
         "react-player": "^2.9.0"
       },
@@ -3314,6 +3317,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/sax": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.0.33.tgz",
@@ -4148,7 +4160,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -10509,6 +10520,22 @@
         "node": ">=10"
       }
     },
+    "node_modules/gatsby-plugin-react-helmet": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-4.15.0.tgz",
+      "integrity": "sha512-wA3DbF7njlp4TkgWz3M8kBV3OBahE/1TJmF20rFAm5OBt3ak9VCg8x6CjB73qVdJPsyd4ETF7fhxjgrgVmXwpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      },
+      "peerDependencies": {
+        "gatsby": "^3.0.0-next.0",
+        "react-helmet": "^5.1.3 || ^6.0.0"
+      }
+    },
     "node_modules/gatsby-plugin-react-svg": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-react-svg/-/gatsby-plugin-react-svg-3.3.0.tgz",
@@ -10566,6 +10593,26 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/gatsby-plugin-sitemap": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-sitemap/-/gatsby-plugin-sitemap-4.11.0.tgz",
+      "integrity": "sha512-DMzdyJxzUDawSt81SrnieDYLYru57Z0lYADBLbfM/eQacvXA0wGN/HtDIG1laWrToR/Er1WZqGFBEyfnIAu5Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "common-tags": "^1.8.0",
+        "minimatch": "^3.0.4",
+        "sitemap": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      },
+      "peerDependencies": {
+        "gatsby": "^3.0.0-next.0",
+        "react": "^16.9.0 || ^17.0.0",
+        "react-dom": "^16.9.0 || ^17.0.0"
       }
     },
     "node_modules/gatsby-plugin-typescript": {
@@ -19461,6 +19508,21 @@
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
       "license": "MIT"
     },
+    "node_modules/react-helmet": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
+      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.1.1",
+        "react-side-effect": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
+      }
+    },
     "node_modules/react-html-parser": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/react-html-parser/-/react-html-parser-2.0.2.tgz",
@@ -19508,6 +19570,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-side-effect": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.2.tgz",
+      "integrity": "sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/read": {
@@ -21526,6 +21597,31 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
+    },
+    "node_modules/sitemap": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-7.1.3.tgz",
+      "integrity": "sha512-tAjEd+wt/YwnEbfNB2ht51ybBJxbEWwe5ki/Z//Wh0rpBFTCUSj46GnxUKEWzhfuJTsee8x3lybHxFgUMig2hw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^17.0.5",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "sitemap": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=12.0.0",
+        "npm": ">=5.6.0"
+      }
+    },
+    "node_modules/sitemap/node_modules/@types/node": {
+      "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
       "license": "MIT"
     },
     "node_modules/slash": {

--- a/package.json
+++ b/package.json
@@ -31,8 +31,10 @@
     "gatsby-plugin-mdx": "^2.14.0",
     "gatsby-plugin-mdx-embed": "0.0.20-alpha",
     "gatsby-plugin-page-creator": "^3.14.0",
+    "gatsby-plugin-react-helmet": "^4.15.0",
     "gatsby-plugin-react-svg": "^3.1.0",
     "gatsby-plugin-sharp": "^3.14.0",
+    "gatsby-plugin-sitemap": "^4.11.0",
     "gatsby-remark-codepen": "^0.1.1",
     "gatsby-source-filesystem": "^3.14.0",
     "gatsby-transformer-remark": "^4.11.0",
@@ -40,6 +42,7 @@
     "postcss-import": "^14.0.2",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
+    "react-helmet": "^6.1.0",
     "react-html-parser": "^2.0.2",
     "react-player": "^2.9.0"
   },

--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -1,0 +1,161 @@
+import React from "react";
+import { Helmet } from "react-helmet";
+import { useStaticQuery, graphql } from "gatsby";
+
+// Every page's <head> metadata, in one place.
+//
+// This project is on Gatsby 3, which predates the built-in Head API (added in
+// 4.19), so react-helmet is the mechanism. gatsby-plugin-react-helmet flushes
+// whatever Helmet collects into the static HTML at build time, which is what
+// crawlers and social scrapers actually read — they do not run the hydration
+// bundle, so a tag that only appears client-side is a tag that does not exist
+// as far as SEO is concerned.
+//
+// Callers pass `path`, the page's canonical route ("/blog/post/foo/"), rather
+// than letting the component read window.location. Under a PR preview build
+// the real location carries a /pr-preview/pr-N prefix, and deriving canonical
+// from it would point every preview at itself instead of at production.
+
+const IS_ABSOLUTE = /^([a-z][a-z0-9+.-]*:|\/\/)/i;
+
+const Seo = ({
+  title,
+  description,
+  path = "/",
+  image,
+  type = "website",
+  publishedAt,
+  tags,
+  noindex = false,
+  schema,
+}) => {
+  const { site } = useStaticQuery(graphql`
+    query SeoMetadataQuery {
+      site {
+        siteMetadata {
+          siteUrl
+          pathPrefix
+          isPreview
+          title
+          titleTemplate
+          description
+          author
+          defaultImage
+          social {
+            github
+            linkedin
+            devto
+          }
+        }
+      }
+    }
+  `);
+
+  const meta = site.siteMetadata;
+
+  // Trailing slash matters: Gatsby emits /blog/post/foo/ and a canonical of
+  // /blog/post/foo would name a URL that redirects, splitting the signal.
+  const normalizedPath = path.endsWith("/") ? path : `${path}/`;
+  const canonical = `${meta.siteUrl}${normalizedPath}`;
+
+  // Canonical always points at production, but og:image has to resolve where
+  // the page is actually being served, or preview cards break. Hence the
+  // prefix here and not above.
+  const assetBase = meta.pathPrefix
+    ? `${meta.siteUrl}/${meta.pathPrefix}`
+    : meta.siteUrl;
+
+  const toAbsolute = (src) =>
+    !src ? null : IS_ABSOLUTE.test(src) ? src : `${assetBase}${src}`;
+
+  const pageTitle = title || meta.title;
+  // The template would render "Thiago Colen — Thiago Colen" on the home page.
+  const fullTitle =
+    title && meta.titleTemplate
+      ? meta.titleTemplate.replace("%s", title)
+      : pageTitle;
+
+  const pageDescription = description || meta.description;
+  const socialImage = toAbsolute(image || meta.defaultImage);
+  const isNoindex = noindex || meta.isPreview;
+
+  // A post is a BlogPosting; anything else falls back to whatever the caller
+  // supplied. `schema` accepts one object or an array of them.
+  const structuredData =
+    schema ||
+    (type === "article"
+      ? {
+          "@context": "https://schema.org",
+          "@type": "BlogPosting",
+          headline: pageTitle,
+          description: pageDescription,
+          ...(socialImage ? { image: socialImage } : {}),
+          ...(publishedAt ? { datePublished: publishedAt } : {}),
+          ...(tags && tags.length ? { keywords: tags.join(", ") } : {}),
+          author: { "@type": "Person", name: meta.author },
+          publisher: { "@type": "Person", name: meta.author },
+          mainEntityOfPage: { "@type": "WebPage", "@id": canonical },
+          url: canonical,
+        }
+      : null);
+
+  const schemaList = !structuredData
+    ? []
+    : Array.isArray(structuredData)
+    ? structuredData
+    : [structuredData];
+
+  return (
+    <Helmet>
+      <title>{fullTitle}</title>
+      <meta name="description" content={pageDescription} />
+      <link rel="canonical" href={canonical} />
+      <meta name="author" content={meta.author} />
+
+      {/* Preview builds live on the production domain, so without this Google
+          would index /pr-preview/pr-N/ copies of every page. */}
+      {isNoindex ? (
+        <meta name="robots" content="noindex, nofollow" />
+      ) : (
+        <meta name="robots" content="index, follow, max-image-preview:large" />
+      )}
+
+      {/* Open Graph — Facebook, LinkedIn, Slack, WhatsApp */}
+      <meta property="og:site_name" content={meta.title} />
+      <meta property="og:type" content={type} />
+      <meta property="og:title" content={fullTitle} />
+      <meta property="og:description" content={pageDescription} />
+      <meta property="og:url" content={canonical} />
+      {socialImage && <meta property="og:image" content={socialImage} />}
+      {socialImage && <meta property="og:image:alt" content={pageTitle} />}
+
+      {type === "article" && publishedAt && (
+        <meta property="article:published_time" content={publishedAt} />
+      )}
+      {type === "article" && <meta property="article:author" content={meta.author} />}
+      {type === "article" &&
+        tags &&
+        tags.map((tag) => (
+          <meta key={tag} property="article:tag" content={tag} />
+        ))}
+
+      {/* Twitter/X. No handle to claim, so summary_large_image plus the shared
+          OG values is all that resolves — twitter:site would need an account. */}
+      <meta
+        name="twitter:card"
+        content={socialImage ? "summary_large_image" : "summary"}
+      />
+      <meta name="twitter:title" content={fullTitle} />
+      <meta name="twitter:description" content={pageDescription} />
+      {socialImage && <meta name="twitter:image" content={socialImage} />}
+
+      {schemaList.map((entry, index) => (
+        <script key={index} type="application/ld+json">
+          {JSON.stringify(entry)}
+        </script>
+      ))}
+    </Helmet>
+  );
+};
+
+export default Seo;

--- a/src/templates/404.js
+++ b/src/templates/404.js
@@ -1,5 +1,6 @@
 import * as React from "react"
 import { Link } from "gatsby"
+import Seo from "../components/seo"
 
 // styles
 const pageStyles = {
@@ -28,7 +29,10 @@ const codeStyles = {
 const NotFoundPage = () => {
   return (
     <main style={pageStyles}>
-      <title>Not found</title>
+      {/* Was a bare <title> inside <main>, copied from a Gatsby 4 starter where
+          the Head API hoists it. On Gatsby 3 it rendered a <title> element in
+          the body, which no crawler reads as the document title. */}
+      <Seo title="Page not found" path="/404/" noindex />
       <h1 style={headingStyles}>Page not found</h1>
       <p style={paragraphStyles}>
         Sorry{" "}

--- a/src/templates/aboutPage.js
+++ b/src/templates/aboutPage.js
@@ -3,12 +3,21 @@ import React from "react";
 import MainMenu from "../components/mainMenu";
 import Footer from "../components/footer";
 import Container from "../components/container";
+import Seo from "../components/seo";
 
 // TODO: What are we going to put here?
 
 const AboutPage = ({ pageContext }) => {
   return (
     <>
+      {/* noindex until this page has actual content — an empty page in the
+          index is a quality signal working against the rest of the site. */}
+      <Seo
+        title="About"
+        description="About Thiago Colen."
+        path="/about/"
+        noindex
+      />
       <MainMenu activePage="about" />
       <Container>
         <h1 className="text-red-500 text-3xl font-semibold mb-6">About</h1>

--- a/src/templates/blogPage.js
+++ b/src/templates/blogPage.js
@@ -4,6 +4,7 @@ import Footer from "../components/footer";
 import Container from "../components/container";
 import Logo from "../components/logo";
 import ArticleList from "../components/articleList";
+import Seo from "../components/seo";
 
 // TODO: design references
 // https://mir-s3-cdn-cf.behance.net/project_modules/2800_opt_1/31dec0139215579.622b7213a3ce5.png
@@ -13,6 +14,11 @@ const BlogPage = ({ pageContext: { articlesList } }) => {
 
   return (
     <>
+      <Seo
+        title="Blog"
+        description="Long-form writing on algorithms, data structures, system design, and cellular automata."
+        path="/blog/"
+      />
       <MainMenu activePage="blog" />
       <Container>
         <Logo />

--- a/src/templates/homePage.js
+++ b/src/templates/homePage.js
@@ -3,6 +3,7 @@ import { navigate } from "gatsby";
 import { ArrowCircleRightIcon } from "@heroicons/react/solid";
 import { songsSnippets } from "../utils/constants";
 import Poster from "../components/poster";
+import Seo from "../components/seo";
 
 const HomePage = ({ pageContext }) => {
 
@@ -59,6 +60,9 @@ const HomePage = ({ pageContext }) => {
 
   return (
     <React.Fragment>
+      {/* Superseded by homePage2 at /. Kept reachable but out of the index so
+          it cannot compete with the real home page for the same terms. */}
+      <Seo title="Home" path="/homepage/" noindex />
       <ArrowComponent />
       <SentenceComponent />
       <Poster posterType="full" />

--- a/src/templates/homePage2.js
+++ b/src/templates/homePage2.js
@@ -5,6 +5,30 @@ import ArticleList from "../components/articleList";
 import Container from "../components/container";
 import Footer from "../components/footer";
 import LoadingScreen from "../components/loadingScreen";
+import Seo from "../components/seo";
+
+// The home page is both a personal identity page and the blog's front door,
+// so it declares both entities. sameAs is what lets a search engine connect
+// this site to the GitHub/LinkedIn/dev.to profiles as one person.
+const HOME_SCHEMA = [
+  {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    name: "Thiago Colen",
+    url: "https://thiagocolen.github.io/",
+    sameAs: [
+      "https://github.com/thiagocolen",
+      "https://www.linkedin.com/in/thiagocolen/",
+      "https://dev.to/thiagocolen",
+    ],
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: "Thiago Colen",
+    url: "https://thiagocolen.github.io/",
+  },
+];
 
 const useSafeLayoutEffect = typeof window !== "undefined" ? React.useLayoutEffect : React.useEffect;
 
@@ -31,6 +55,8 @@ const HomePage2 = ({ location, pageContext: { articlesList } }) => {
 
   return (
     <>
+      <Seo path="/" schema={HOME_SCHEMA} />
+
       {loadState === "loading" && (
         <LoadingScreen onDismiss={handleInitialize} isShort={isShortAnimation} />
       )}

--- a/src/templates/postPage.js
+++ b/src/templates/postPage.js
@@ -5,6 +5,7 @@ import { ShareIcon, CheckIcon, MoonIcon, SunIcon } from "@heroicons/react/outlin
 import Footer from "../components/footer";
 import Container from "../components/container";
 import Poster from "../components/poster";
+import Seo from "../components/seo";
 import { datePipe } from "../utils/datePipe";
 import { assetUrl } from "../utils/assetUrl";
 
@@ -251,6 +252,19 @@ const PostPage = ({ pageContext: { article }, data }) => {
 
   return (
     <>
+      {/* headline is the subtitle shown under the title; it reads better as a
+          search snippet than the body's opening line, so it seeds the
+          description when the post has no explicit one. */}
+      <Seo
+        title={article.title}
+        description={article.description || article.headline}
+        path={`/blog/post/${article.slug}/`}
+        image={article.cover_image}
+        type="article"
+        publishedAt={article.published_at}
+        tags={article.tags}
+        noindex={article.status !== "published"}
+      />
       <Poster
         colorOpacity={0.8}
         extraControls={

--- a/static/google34360e88b732e495.html
+++ b/static/google34360e88b732e495.html
@@ -1,0 +1,1 @@
+google-site-verification: google34360e88b732e495.html

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,13 @@
+User-agent: *
+Allow: /
+
+# PR previews are deployed to this same domain by .github/workflows/pr-preview.yml
+# (https://thiagocolen.github.io/pr-preview/pr-N/). They are copies of the site
+# and must never be indexed. The pages also carry a noindex tag; this rule keeps
+# crawlers from spending budget fetching them at all.
+Disallow: /pr-preview/
+
+# gatsby-plugin-sitemap v4 emits an index plus numbered chunks under /sitemap/,
+# not a single /sitemap.xml. Pointing at the index is what lets a crawler find
+# the chunks; /sitemap.xml is a 404 on this build.
+Sitemap: https://thiagocolen.github.io/sitemap/sitemap-index.xml


### PR DESCRIPTION
## What

The site had **no SEO metadata whatsoever** — no `<title>` or description on any page, no canonical URLs, no Open Graph/Twitter cards, no sitemap, no `robots.txt`, and no `lang` on `<html>`. Shared links rendered as bare URLs with no title, image, or summary.

## Why react-helmet and not the Head API

This project is on **Gatsby 3.15**, which predates the built-in Head API (added in 4.19). So this uses `react-helmet` via `gatsby-plugin-react-helmet`, which flushes tags into the **static HTML at build time** — crawlers and social scrapers don't run the hydration bundle, so a client-only tag doesn't exist as far as SEO is concerned.

Plugin versions are pinned to the Gatsby 3 line (`gatsby-plugin-react-helmet@4`, `gatsby-plugin-sitemap@4`); the v5 releases require Gatsby 4.

## Changes

| Area | Change |
|---|---|
| `gatsby-config.js` | `siteMetadata` (canonical origin, title template, description, social profiles) + both plugins |
| `src/components/seo.js` | **New.** Single source of head metadata for every page |
| Templates | `Seo` wired into all six (home, blog, post, about, `/homepage/`, 404) |
| Structured data | `BlogPosting` per post; `Person` + `WebSite` on the home page |
| `static/robots.txt` | **New.** Points at the sitemap index, disallows `/pr-preview/` |
| `gatsby-ssr.js` | `lang="en"` on `<html>` |

## PR previews were an indexing hazard

Previews deploy to the **production domain** (`thiagocolen.github.io/pr-preview/pr-N/`). Adding canonical/OG tags naively would have made every preview an indexable duplicate of the real site.

So preview builds emit `noindex, nofollow` while **canonical still points at production**, and `og:image` resolves under the preview prefix so preview cards still render. Verified by building with `PATH_PREFIX=pr-preview/pr-99`:

```html
<link rel="canonical" href="https://thiagocolen.github.io/blog/post/conway-s-game-of-life-explained/"/>
<meta name="robots" content="noindex, nofollow"/>
<meta property="og:image" content="https://thiagocolen.github.io/pr-preview/pr-99/images/conway-s-game-of-life-explained.jpg"/>
```

Canonical is built from an explicit `path` prop rather than `window.location` — precisely so the prefix can't leak into it.

## Also fixed

`src/templates/404.js` had a bare `<title>` inside `<main>`, copied from a Gatsby 4 starter where the Head API hoists it. On Gatsby 3 it rendered a `<title>` **element in the body**, which nothing reads as the document title.

## Verification

Production build succeeds. Emitted HTML confirmed to contain title, description, canonical, OG, Twitter, and valid JSON-LD. Sitemap contains 17 URLs (15 posts + `/` + `/blog/`), correctly excluding the `/about/` stub, the superseded `/homepage/`, and the 404.

## Follow-ups (not in this PR)

- **No default share image.** `defaultImage` is intentionally empty — pointing at a nonexistent file yields a broken card. Drop a 1200×630 image at `static/images/og-default.jpg` and set `defaultImage` in `gatsby-config.js`. Posts are unaffected (they use their `cover_image`).
- `/about/` is a stub, so it's `noindex` **and** excluded from the sitemap. Remove it from both places once it has content.
- No Twitter/X handle exists, so `twitter:site`/`creator` are omitted; cards still render via the OG values.
- Submit the sitemap in Google Search Console — nothing here triggers a crawl on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N6MYj8MNMWR6nwd49ui4QJ