### PR TITLE
feat(seo): reflect current professional identity in brand metadata

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -30,13 +30,11 @@ module.exports = {
     title: "Thiago Colen",
     titleTemplate: "%s — Thiago Colen",
     description:
-      "Essays on algorithms, system design, and the strange places where simple rules produce complex behaviour, by Thiago Colen.",
+      "Thiago Colen — AI Engineer building agentic systems (LangGraph, Retrieval-Augmented Generation, Anthropic Claude) and software/front-end architecture. Also writes essays on algorithms, system design, and cellular automata.",
     author: "Thiago Colen",
-    // Fallback share image for pages that have no cover of their own. Left
-    // empty deliberately: pointing at a file that does not exist produces a
-    // broken preview card, which is worse than no card. Drop a 1200x630 image
-    // at static/images/og-default.jpg and set this to "/images/og-default.jpg".
-    defaultImage: "",
+    // Fallback share image for pages that have no cover of their own (home,
+    // about). Reuses an existing post cover rather than a dedicated OG asset.
+    defaultImage: "/images/conway-s-game-of-life-explained.jpg",
     social: {
       github: "https://github.com/thiagocolen",
       linkedin: "https://www.linkedin.com/in/thiagocolen/",

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -60,6 +60,28 @@ const Footer = () => {
       <div className="absolute inset-0 opacity-5 pointer-events-none bg-[repeating-linear-gradient(45deg,#000,#000_10px,transparent_10px,transparent_20px)]" />
 
       <div className="container mx-auto relative z-10">
+        {/* Bio block: the site has no dedicated About page, so this is where
+            crawlable, real bio text about Thiago lives — on every page,
+            since Footer is shared across post/blog/home templates. */}
+        <div className="mb-10">
+          <div className="bg-white border-4 border-black p-6 sm:p-8 shadow-md rounded max-w-3xl">
+            <h2 className="font-head text-sm uppercase tracking-widest font-extrabold mb-2">
+              Thiago Colen
+            </h2>
+            <p className="font-domine text-xs sm:text-sm uppercase tracking-wide font-bold text-black text-opacity-70 mb-3">
+              AI Engineer — Agentic Systems (LangGraph, RAG) &amp; Anthropic Claude · Software &amp; Front-End Architecture
+            </p>
+            <p className="font-sans text-sm sm:text-base leading-relaxed text-black">
+              I build production-grade agentic systems — most recently a cloud-native Deep Agent
+              grounded by a custom Retrieval-Augmented Generation pipeline, deployed on AWS via
+              Terraform and reachable from an IDE, a REST API, and the Model Context Protocol.
+              That sits on top of years as a Front-End Developer and Web Architect, building
+              proprietary front-end frameworks and Micro Front-End / Web Components
+              architectures for large-scale applications.
+            </p>
+          </div>
+        </div>
+
         <div className="grid grid-cols-1 lg:grid-cols-12 gap-8 items-start">
           
           {/* Column 1: Now Playing Music Console Box (Slices lyric into Short Title and Long Content) */}

--- a/src/templates/homePage2.js
+++ b/src/templates/homePage2.js
@@ -16,6 +16,19 @@ const HOME_SCHEMA = [
     "@type": "Person",
     name: "Thiago Colen",
     url: "https://thiagocolen.github.io/",
+    jobTitle: "AI Engineer",
+    description:
+      "AI Engineer building production agentic systems (LangGraph, Retrieval-Augmented Generation, Anthropic Claude), with a background in front-end development and web architecture.",
+    knowsAbout: [
+      "Agentic Systems",
+      "LangGraph",
+      "Retrieval-Augmented Generation",
+      "Anthropic Claude",
+      "TypeScript",
+      "AWS",
+      "Terraform",
+      "Front-End Architecture",
+    ],
     sameAs: [
       "https://github.com/thiagocolen",
       "https://www.linkedin.com/in/thiagocolen/",


### PR DESCRIPTION
## Summary

Closes #65.

The site's technical SEO was already solid — `gatsby-plugin-sitemap`, a hand-written `robots.txt`, Google Search Console verification, `html lang="en"`, and a custom `<Seo>` component (`src/components/seo.js`) emitting canonical links, robots meta, full Open Graph/Twitter Card tags, and JSON-LD (`BlogPosting` per post, `Person`+`WebSite` on the home page).

The gap was on the **personal-brand side**: the site-wide meta description, the homepage's `Person` schema, and the footer all framed Thiago purely as an essayist, with no crawlable text reflecting his actual current professional focus (AI Engineering, agentic systems, RAG, Anthropic Claude). That under-targets exactly the search terms a recruiter or potential employer would use.

- **`gatsby-config.js`**
  - Rewrote `siteMetadata.description` — the fallback `<meta name="description">` for any page that doesn't pass its own, notably the home page — to lead with the AI Engineer / agentic-systems identity while keeping the existing essay framing.
  - Set `siteMetadata.defaultImage` to an existing post cover (`/images/conway-s-game-of-life-explained.jpg`) so pages without their own cover image (home, footer-only pages) get a real Open Graph / Twitter share card instead of a broken/missing one.

- **`src/components/footer.js`**
  - Added a real, crawlable bio block (name, one-line headline, 2-sentence summary) styled to match the site's existing brutalist card design. The site has no dedicated About page — `/about/` is an empty, noindexed stub not linked from the nav — so the footer (shared by every template: post, blog, home) is where this content now lives, giving it site-wide reach.

- **`src/templates/homePage2.js`**
  - Enriched the homepage's `Person` JSON-LD entry with `jobTitle`, a short `description`, and a `knowsAbout` array (Agentic Systems, LangGraph, Retrieval-Augmented Generation, Anthropic Claude, TypeScript, AWS, Terraform, Front-End Architecture), strengthening the entity signal search engines associate with the site.

## Out of scope (deferred)

- Google Analytics/GA4 — intentionally skipped for this pass.
- Touching `/about/` or `mainMenu.js` — superseded by the footer bio.
- Optimizing post cover/figure images via `gatsby-plugin-image` (currently plain `<img>`) — a real Core Web Vitals opportunity, but a separate, larger change.
- An RSS feed via `gatsby-plugin-feed`.

## Test plan

- [x] `gatsby build` completes with no errors.
- [x] Verified in the built `public/index.html`:
  - `<meta name="description">` leads with the new AI Engineer copy.
  - `og:image` / `twitter:image` resolve to the Conway's Game of Life cover URL.
  - The `Person` JSON-LD block includes `jobTitle` and `knowsAbout`.
  - The new footer bio text is present in the rendered HTML.
- [ ] `gatsby develop` and eyeball the footer bio block on `/`, a blog post, and `/blog/` for visual/layout regressions.
- [ ] Paste the built home page's JSON-LD into Google's Rich Results Test to confirm it still validates as `Person`/`WebSite`/`BlogPosting`.

https://claude.ai/code/session_01V6ewY5wgAfa3uUPAmnPpCu