### PR TITLE
Reword footer bio title from em dash to comma

### DIFF
--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -69,7 +69,7 @@ const Footer = () => {
               Thiago Colen
             </h2>
             <p className="font-domine text-xs sm:text-sm uppercase tracking-wide font-bold text-black text-opacity-70 mb-3">
-              AI Engineer — Agentic Systems (LangGraph, RAG) &amp; Anthropic Claude · Software &amp; Front-End Architecture
+              AI Engineering, Agentic Systems (LangGraph, RAG) &amp; Anthropic Claude · Software &amp; Front-End Architecture
             </p>
             <p className="font-sans text-sm sm:text-base leading-relaxed text-black">
               I build production-grade agentic systems — most recently a cloud-native Deep Agent


### PR DESCRIPTION
## Summary
- Rewords the footer bio subtitle from "AI Engineer — Agentic Systems (LangGraph, RAG) & Anthropic Claude · Software & Front-End Architecture" to "AI Engineering, Agentic Systems (LangGraph, RAG) & Anthropic Claude · Software & Front-End Architecture"

## Test plan
- [ ] Visually confirm the footer bio renders correctly on the homepage and a blog post page

https://claude.ai/code/session_01V6ewY5wgAfa3uUPAmnPpCu