### PR TITLE
Rewrite footer bio copy in formal, third-person tone

### DIFF
--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -72,12 +72,14 @@ const Footer = () => {
               AI Engineering, Agentic Systems (LangGraph, RAG) &amp; Anthropic Claude · Software &amp; Front-End Architecture
             </p>
             <p className="font-sans text-sm sm:text-base leading-relaxed text-black">
-              I build production-grade agentic systems — most recently a cloud-native Deep Agent
-              grounded by a custom Retrieval-Augmented Generation pipeline, deployed on AWS via
-              Terraform and reachable from an IDE, a REST API, and the Model Context Protocol.
-              That sits on top of years as a Front-End Developer and Web Architect, building
-              proprietary front-end frameworks and Micro Front-End / Web Components
-              architectures for large-scale applications.
+              Building a production-grade agentic system on AWS, combining LangChain-based Deep
+              Agents with retrieval-augmented generation to ground AI-driven applications in
+              reliable, context-aware reasoning. Brings a background spanning front-end
+              architecture and cloud infrastructure, with recent focus on designing and deploying
+              scalable AI systems that integrate large language models into real-world products.
+              Experienced in leading technical initiatives across the full stack, from
+              cloud-native infrastructure to user-facing frameworks, with a current emphasis on
+              agentic systems, prompt engineering, and applied AI architecture on AWS.
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Replaces the first-person, technical bio paragraph in the shared footer with a formal, third-person version matching the LinkedIn About section
- Keeps the AI/AWS/LangChain/Deep Agents focus, drops project-specific detail

Closes #82

## Test plan
- [ ] `npm run develop` and confirm the footer bio renders correctly on home/blog/post pages
- [ ] Check text wraps/looks fine at mobile and desktop widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V6ewY5wgAfa3uUPAmnPpCu