### PR TITLE
feat(blog): collapse tag filter list behind a show-all toggle

### DIFF
--- a/src/components/articleList.js
+++ b/src/components/articleList.js
@@ -58,21 +58,35 @@ const ArticleComponent = ({ article, index }) => {
   );
 };
 
+const VISIBLE_TAG_LIMIT = 8;
+
 const ArticleList = ({ articles }) => {
   const [selectedTag, setSelectedTag] = useState(null);
+  const [showAllTags, setShowAllTags] = useState(false);
 
-  // Extract unique tags from articles
-  const allTags = articles.reduce((acc, article) => {
+  // Extract unique tags from articles, with their article counts
+  const tagCounts = articles.reduce((acc, article) => {
     if (article.tags) {
       article.tags.forEach((tag) => {
         const normalizedTag = tag.trim().toLowerCase();
-        if (normalizedTag && !acc.includes(normalizedTag)) {
-          acc.push(normalizedTag);
+        if (normalizedTag) {
+          acc[normalizedTag] = (acc[normalizedTag] || 0) + 1;
         }
       });
     }
     return acc;
-  }, []);
+  }, {});
+
+  // Most-used tags first, so the truncated view surfaces the most relevant ones
+  const allTags = Object.keys(tagCounts).sort(
+    (a, b) => tagCounts[b] - tagCounts[a]
+  );
+
+  const hiddenTagCount = allTags.length - VISIBLE_TAG_LIMIT;
+  const visibleTags =
+    showAllTags || hiddenTagCount <= 0
+      ? allTags
+      : allTags.slice(0, VISIBLE_TAG_LIMIT);
 
   // Filter articles based on selected tag
   const filteredArticles = selectedTag
@@ -112,25 +126,29 @@ const ArticleList = ({ articles }) => {
             </button>
 
             {/* Individual Tag Buttons */}
-            {allTags.map((tag) => {
-              const count = articles.filter(
-                (a) => a.tags && a.tags.some((t) => t.trim().toLowerCase() === tag)
-              ).length;
+            {visibleTags.map((tag) => (
+              <button
+                key={tag}
+                onClick={() => setSelectedTag(tag)}
+                className={`font-head text-xs border-2 border-black rounded px-3.5 py-1.5 transition-all duration-100 shadow-xs cursor-pointer select-none uppercase ${
+                  selectedTag === tag
+                    ? "bg-black text-white shadow-none translate-x-[1px] translate-y-[1px]"
+                    : "bg-white text-black hover:bg-primary hover:shadow-none hover:translate-x-[1px] hover:translate-y-[1px]"
+                }`}
+              >
+                #{tag} ({tagCounts[tag]})
+              </button>
+            ))}
 
-              return (
-                <button
-                  key={tag}
-                  onClick={() => setSelectedTag(tag)}
-                  className={`font-head text-xs border-2 border-black rounded px-3.5 py-1.5 transition-all duration-100 shadow-xs cursor-pointer select-none uppercase ${
-                    selectedTag === tag
-                      ? "bg-black text-white shadow-none translate-x-[1px] translate-y-[1px]"
-                      : "bg-white text-black hover:bg-primary hover:shadow-none hover:translate-x-[1px] hover:translate-y-[1px]"
-                  }`}
-                >
-                  #{tag} ({count})
-                </button>
-              );
-            })}
+            {/* Show all / Show less toggle */}
+            {hiddenTagCount > 0 && (
+              <button
+                onClick={() => setShowAllTags((prev) => !prev)}
+                className="font-head text-xs border-2 border-dashed border-black/50 rounded px-3.5 py-1.5 transition-all duration-100 cursor-pointer select-none text-black/60 hover:text-black hover:border-black hover:bg-primary/40"
+              >
+                {showAllTags ? "Show less" : `Show all (+${hiddenTagCount})`}
+              </button>
+            )}
           </div>
         </div>
       )}


### PR DESCRIPTION
Closes #78.

## Summary
- Sort tags by article count (descending) instead of frontmatter order.
- Cap the visible tag-filter buttons to the 8 most-used tags.
- Add a "Show all (+N)" / "Show less" toggle to reveal/hide the rest.
- No change to filtering logic, the "ALL POSTS" button, or per-tag counts.

## Why
`ArticleList` (`src/components/articleList.js`) rendered a button for every unique tag with no cap — currently ~24 across 18 posts — turning the filter bar into a multi-row wall of buttons above the article grid.

## Test plan
- [x] `gatsby build` succeeds.
- [x] `gatsby serve` + inspected rendered `/blog/` HTML: only the 8 highest-count tags render by default (`beginners (9)`, `javascript (5)`, `algorithms (4)`, `java (4)`, `cellular-automata (2)`, `emergence (2)`, `computation (2)`, `build-in-public (2)`), followed by `Show all (+16)`, matching the 24 total unique tags.