### PR TITLE
feat(about): build out a real about/profile page

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -67,14 +67,12 @@ module.exports = {
       options: {
         // /homepage/ is a superseded splash variant of /, and the 404 is not a
         // real destination — listing either invites duplicate-content and
-        // soft-404 warnings in Search Console. /about/ is a stub and carries a
-        // matching noindex in aboutPage.js; submitting a URL you also tell
-        // crawlers to ignore is a contradiction Search Console reports. Drop
-        // it from both places once the page has real content.
+        // soft-404 warnings in Search Console. /about/ now has real,
+        // indexable content (see aboutPage.js), so it's submitted like any
+        // other page.
         // `excludes`, not `exclude` — renamed in gatsby-plugin-sitemap v4.
         excludes: [
           "/homepage/",
-          "/about/",
           "/404/",
           "/404.html",
           "/dev-404-page/",

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { Link } from "gatsby";
 import { songsSnippets } from "../utils/constants";
 
 const Footer = () => {
@@ -81,6 +82,12 @@ const Footer = () => {
               cloud-native infrastructure to user-facing frameworks, with a current emphasis on
               agentic systems, prompt engineering, and applied AI architecture on AWS.
             </p>
+            <Link
+              to="/about/"
+              className="inline-block mt-4 font-head text-xs uppercase tracking-widest font-extrabold underline decoration-2 underline-offset-2 hover:text-primary-hover"
+            >
+              Read the full bio &rarr;
+            </Link>
           </div>
         </div>
 

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import { Link } from "gatsby";
 import { songsSnippets } from "../utils/constants";
 
-const Footer = ({ hideBio = false }) => {
+const Footer = ({ hideBio = false, hideConnect = false }) => {
   const [song, setSong] = useState({ title: "", content: "" });
 
   useEffect(() => {
@@ -98,7 +98,7 @@ const Footer = ({ hideBio = false }) => {
         <div className="grid grid-cols-1 lg:grid-cols-12 gap-8 items-start">
           
           {/* Column 1: Now Playing Music Console Box (Slices lyric into Short Title and Long Content) */}
-          <div className="lg:col-span-7 w-full">
+          <div className={`${hideConnect ? "lg:col-span-12" : "lg:col-span-7"} w-full`}>
             <div className="bg-white border-4 border-black p-6 shadow-md relative rounded transform -rotate-1 hover:rotate-0 transition-transform duration-200">
               {song.title && (
                 <div className="absolute -top-3.5 left-4 max-w-[85%] bg-black text-white px-2.5 py-1 text-[9px] font-head uppercase border-2 border-black tracking-widest leading-snug break-words">
@@ -112,6 +112,7 @@ const Footer = ({ hideBio = false }) => {
           </div>
 
           {/* Column 2: Brutalist Connect Dashboard (Visual Social Icons) */}
+          {!hideConnect && (
           <div className="lg:col-span-5 w-full flex flex-col space-y-4 lg:items-end">
             <div className="font-head text-xs uppercase tracking-wider text-black font-extrabold flex items-center space-x-2">
               <span className="inline-block w-2.5 h-2.5 bg-black rounded-full" />
@@ -120,9 +121,9 @@ const Footer = ({ hideBio = false }) => {
 
             {/* Row of visual brutalist square buttons containing SVGs */}
             <div className="flex flex-wrap gap-4 lg:justify-end">
-              <a 
-                href="https://dev.to/thiagocolen" 
-                target="_blank" 
+              <a
+                href="https://dev.to/thiagocolen"
+                target="_blank"
                 rel="noopener noreferrer"
                 className="w-12 h-12 flex items-center justify-center border-3 border-black bg-white hover:bg-black hover:text-white text-black rounded shadow-xs hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-none transition-all"
                 aria-label="Dev.to"
@@ -132,8 +133,8 @@ const Footer = ({ hideBio = false }) => {
                 </svg>
               </a>
 
-              <a 
-                href="https://github.com/thiagocolen" 
+              <a
+                href="https://github.com/thiagocolen"
                 target="_blank" 
                 rel="noopener noreferrer"
                 className="w-12 h-12 flex items-center justify-center border-3 border-black bg-white hover:bg-black hover:text-white text-black rounded shadow-xs hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-none transition-all"
@@ -167,6 +168,7 @@ const Footer = ({ hideBio = false }) => {
               </a>
             </div>
           </div>
+          )}
 
         </div>
 

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -75,16 +75,11 @@ const Footer = ({ hideBio = false, hideConnect = false }) => {
               <p className="font-domine text-xs sm:text-sm uppercase tracking-wide font-bold text-black text-opacity-70 mb-3">
                 AI Engineering, Agentic Systems (LangGraph, RAG) &amp; Anthropic Claude · Software &amp; Front-End Architecture
               </p>
-              <p className="font-sans text-sm sm:text-base leading-relaxed text-black">
-                Experienced in leading technical initiatives across the full stack, from
-                cloud-native infrastructure to user-facing frameworks, with a current emphasis on
-                agentic systems, prompt engineering, and applied AI architecture on AWS.
-              </p>
               <Link
                 to="/about/"
                 className="inline-block mt-4 font-head text-xs uppercase tracking-widest font-extrabold underline decoration-2 underline-offset-2 hover:text-primary-hover"
               >
-                Read the full bio &rarr;
+                Read about &rarr;
               </Link>
             </div>
           </div>

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -76,11 +76,6 @@ const Footer = ({ hideBio = false, hideConnect = false }) => {
                 AI Engineering, Agentic Systems (LangGraph, RAG) &amp; Anthropic Claude · Software &amp; Front-End Architecture
               </p>
               <p className="font-sans text-sm sm:text-base leading-relaxed text-black">
-                Building a production-grade agentic system on AWS, combining LangChain-based Deep
-                Agents with retrieval-augmented generation to ground AI-driven applications in
-                reliable, context-aware reasoning. Brings a background spanning front-end
-                architecture and cloud infrastructure, with recent focus on designing and deploying
-                scalable AI systems that integrate large language models into real-world products.
                 Experienced in leading technical initiatives across the full stack, from
                 cloud-native infrastructure to user-facing frameworks, with a current emphasis on
                 agentic systems, prompt engineering, and applied AI architecture on AWS.

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import { Link } from "gatsby";
 import { songsSnippets } from "../utils/constants";
 
-const Footer = () => {
+const Footer = ({ hideBio = false }) => {
   const [song, setSong] = useState({ title: "", content: "" });
 
   useEffect(() => {
@@ -63,33 +63,37 @@ const Footer = () => {
       <div className="container mx-auto relative z-10">
         {/* Bio block: the site has no dedicated About page, so this is where
             crawlable, real bio text about Thiago lives — on every page,
-            since Footer is shared across post/blog/home templates. */}
-        <div className="mb-10">
-          <div className="bg-white border-4 border-black p-6 sm:p-8 shadow-md rounded max-w-3xl">
-            <h2 className="font-head text-sm uppercase tracking-widest font-extrabold mb-2">
-              Thiago Colen
-            </h2>
-            <p className="font-domine text-xs sm:text-sm uppercase tracking-wide font-bold text-black text-opacity-70 mb-3">
-              AI Engineering, Agentic Systems (LangGraph, RAG) &amp; Anthropic Claude · Software &amp; Front-End Architecture
-            </p>
-            <p className="font-sans text-sm sm:text-base leading-relaxed text-black">
-              Building a production-grade agentic system on AWS, combining LangChain-based Deep
-              Agents with retrieval-augmented generation to ground AI-driven applications in
-              reliable, context-aware reasoning. Brings a background spanning front-end
-              architecture and cloud infrastructure, with recent focus on designing and deploying
-              scalable AI systems that integrate large language models into real-world products.
-              Experienced in leading technical initiatives across the full stack, from
-              cloud-native infrastructure to user-facing frameworks, with a current emphasis on
-              agentic systems, prompt engineering, and applied AI architecture on AWS.
-            </p>
-            <Link
-              to="/about/"
-              className="inline-block mt-4 font-head text-xs uppercase tracking-widest font-extrabold underline decoration-2 underline-offset-2 hover:text-primary-hover"
-            >
-              Read the full bio &rarr;
-            </Link>
+            since Footer is shared across post/blog/home templates. Hidden on
+            the About page itself (hideBio) — that page already is the bio,
+            so repeating it in the footer would be redundant. */}
+        {!hideBio && (
+          <div className="mb-10">
+            <div className="bg-white border-4 border-black p-6 sm:p-8 shadow-md rounded max-w-3xl">
+              <h2 className="font-head text-sm uppercase tracking-widest font-extrabold mb-2">
+                Thiago Colen
+              </h2>
+              <p className="font-domine text-xs sm:text-sm uppercase tracking-wide font-bold text-black text-opacity-70 mb-3">
+                AI Engineering, Agentic Systems (LangGraph, RAG) &amp; Anthropic Claude · Software &amp; Front-End Architecture
+              </p>
+              <p className="font-sans text-sm sm:text-base leading-relaxed text-black">
+                Building a production-grade agentic system on AWS, combining LangChain-based Deep
+                Agents with retrieval-augmented generation to ground AI-driven applications in
+                reliable, context-aware reasoning. Brings a background spanning front-end
+                architecture and cloud infrastructure, with recent focus on designing and deploying
+                scalable AI systems that integrate large language models into real-world products.
+                Experienced in leading technical initiatives across the full stack, from
+                cloud-native infrastructure to user-facing frameworks, with a current emphasis on
+                agentic systems, prompt engineering, and applied AI architecture on AWS.
+              </p>
+              <Link
+                to="/about/"
+                className="inline-block mt-4 font-head text-xs uppercase tracking-widest font-extrabold underline decoration-2 underline-offset-2 hover:text-primary-hover"
+              >
+                Read the full bio &rarr;
+              </Link>
+            </div>
           </div>
-        </div>
+        )}
 
         <div className="grid grid-cols-1 lg:grid-cols-12 gap-8 items-start">
           

--- a/src/components/mainMenu.js
+++ b/src/components/mainMenu.js
@@ -23,11 +23,19 @@ const MainMenu = (props) => {
         {/* Menu Links */}
         <ul className="flex items-center space-x-4 font-head text-sm">
           <li>
-            <Link 
-              to="/" 
+            <Link
+              to="/"
               className={`inline-block border-2 border-black rounded px-3 py-1 shadow-sm transition-all ${activePageClass("home")}`}
             >
               HOME
+            </Link>
+          </li>
+          <li>
+            <Link
+              to="/about/"
+              className={`inline-block border-2 border-black rounded px-3 py-1 shadow-sm transition-all ${activePageClass("about")}`}
+            >
+              ABOUT
             </Link>
           </li>
         </ul>

--- a/src/components/poster.js
+++ b/src/components/poster.js
@@ -27,7 +27,7 @@ const pick = (arr) => arr[Math.floor(Math.random() * arr.length)];
 // `extraControls` lets a page drop a page-specific button into the fixed
 // bottom-left control row (postPage passes its share button), so those buttons
 // line up with the poster/glitch pair instead of needing their own fixed box.
-const Poster = ({ colorOpacity = 0.7, extraControls = null }) => {
+const Poster = ({ colorOpacity = 0.7, extraControls = null, hideControls = false }) => {
   const [currentPosterIndex, setCurrentPosterIndex] = useState(0);
   const [currentColorIndex, setCurrentColorIndex] = useState(0);
   const [isTransitioning, setIsTransitioning] = useState(false);
@@ -119,30 +119,32 @@ const Poster = ({ colorOpacity = 0.7, extraControls = null }) => {
   return (
     <>
       {/* Floating Retro Controls (Change Poster + Glitch Toggle Buttons) */}
-      <div className="fixed bottom-6 left-6 z-50 flex items-center space-x-2 animate-brutalist-wiggle">
-        <button 
-          onClick={changePoster}
-          disabled={isTransitioning}
-          className="font-head text-xs bg-primary text-black border-2 border-black rounded w-control h-control flex items-center justify-center shadow-sm hover:shadow-none hover:translate-x-0.5 hover:translate-y-0.5 active:translate-x-1 active:translate-y-1 active:shadow-xs transition-all duration-150 cursor-pointer select-none disabled:opacity-75 disabled:cursor-not-allowed"
-          title="Switch background video and color theme"
-        >
-          {isTransitioning ? icons.loading : icons.poster}
-        </button>
+      {!hideControls && (
+        <div className="fixed bottom-6 left-6 z-50 flex items-center space-x-2 animate-brutalist-wiggle">
+          <button
+            onClick={changePoster}
+            disabled={isTransitioning}
+            className="font-head text-xs bg-primary text-black border-2 border-black rounded w-control h-control flex items-center justify-center shadow-sm hover:shadow-none hover:translate-x-0.5 hover:translate-y-0.5 active:translate-x-1 active:translate-y-1 active:shadow-xs transition-all duration-150 cursor-pointer select-none disabled:opacity-75 disabled:cursor-not-allowed"
+            title="Switch background video and color theme"
+          >
+            {isTransitioning ? icons.loading : icons.poster}
+          </button>
 
-        <button 
-          onClick={toggleGlitch}
-          className={`font-head text-xs border-2 border-black rounded w-control h-control flex items-center justify-center shadow-sm hover:shadow-none hover:translate-x-0.5 hover:translate-y-0.5 active:translate-x-1 active:translate-y-1 transition-all duration-150 cursor-pointer select-none ${
-            glitchEnabled 
-              ? "bg-accent text-black" 
-              : "bg-red-500 text-white"
-          }`}
-          title={glitchEnabled ? "Glitch effects ON — click to disable" : "Glitch effects OFF — click to enable"}
-        >
-          {glitchEnabled ? icons.glitchOn : icons.glitchOff}
-        </button>
+          <button
+            onClick={toggleGlitch}
+            className={`font-head text-xs border-2 border-black rounded w-control h-control flex items-center justify-center shadow-sm hover:shadow-none hover:translate-x-0.5 hover:translate-y-0.5 active:translate-x-1 active:translate-y-1 transition-all duration-150 cursor-pointer select-none ${
+              glitchEnabled
+                ? "bg-accent text-black"
+                : "bg-red-500 text-white"
+            }`}
+            title={glitchEnabled ? "Glitch effects ON — click to disable" : "Glitch effects OFF — click to enable"}
+          >
+            {glitchEnabled ? icons.glitchOn : icons.glitchOff}
+          </button>
 
-        {extraControls}
-      </div>
+          {extraControls}
+        </div>
+      )}
 
       {/* Fullscreen Video Background & Dual Overlay (Color + Dark) */}
       <div className="fixed inset-0 w-full h-full -z-50 overflow-hidden bg-background pointer-events-none">

--- a/src/templates/aboutPage.js
+++ b/src/templates/aboutPage.js
@@ -2,6 +2,7 @@ import React from "react";
 import MainMenu from "../components/mainMenu";
 import Footer from "../components/footer";
 import Container from "../components/container";
+import Poster from "../components/poster";
 import Seo from "../components/seo";
 
 // ProfilePage + a Person mainEntity is the schema.org shape recommended for a
@@ -84,7 +85,8 @@ const AboutPage = () => {
         schema={ABOUT_SCHEMA}
       />
       <MainMenu activePage="about" />
-      <Container>
+      <Poster />
+      <Container className="bg-transparent">
         <section className="max-w-3xl mx-auto w-full pt-4 pb-16">
           <div className="bg-white border-4 border-black p-6 sm:p-10 shadow-md rounded">
             <h1 className="font-head text-2xl sm:text-3xl font-extrabold mb-2">
@@ -170,7 +172,7 @@ const AboutPage = () => {
           </div>
         </section>
       </Container>
-      <Footer />
+      <Footer hideBio />
     </>
   );
 };

--- a/src/templates/aboutPage.js
+++ b/src/templates/aboutPage.js
@@ -1,5 +1,4 @@
 import React from "react";
-import MainMenu from "../components/mainMenu";
 import Footer from "../components/footer";
 import Container from "../components/container";
 import Poster from "../components/poster";
@@ -38,12 +37,6 @@ const ABOUT_SCHEMA = {
 };
 
 const CONNECT_LINKS = [
-  {
-    label: "Dev.to",
-    href: "https://dev.to/thiagocolen",
-    viewBox: "0 0 512 512",
-    path: "M120.12 208.29c-3.88-2.9-7.77-4.35-11.65-4.35H91.03v104.47h17.45c3.88 0 7.77-1.45 11.65-4.35s5.82-7.25 5.82-13.06v-69.65c-.01-5.8-1.96-10.16-5.83-13.06zM404.1 32H43.9C19.7 32 .06 51.59 0 75.8v360.4C.06 460.41 19.7 480 43.9 480h360.2c24.21 0 43.84-19.59 43.9-43.8V75.8c-.06-24.21-19.7-43.8-43.9-43.8zM154.2 291.19c0 18.81-11.61 47.31-48.36 47.25h-46.4V172.98h47.38c35.44 0 47.36 28.46 47.37 47.28zm100.68-88.66H201.6v38.42h32.57v29.57H201.6v38.41h53.29v29.57h-62.18c-11.16.29-20.44-8.53-20.72-19.69V193.7c-.27-11.15 8.56-20.41 19.71-20.69h63.19zm103.64 115.29c-13.2 30.75-36.85 24.63-47.44 0l-38.53-144.8h32.57l29.71 113.72 29.57-113.72h32.58z",
-  },
   {
     label: "GitHub",
     href: "https://github.com/thiagocolen",
@@ -84,8 +77,7 @@ const AboutPage = () => {
         path="/about/"
         schema={ABOUT_SCHEMA}
       />
-      <MainMenu activePage="about" />
-      <Poster />
+      <Poster hideControls />
       <Container className="bg-transparent">
         <section className="max-w-3xl mx-auto w-full pt-4 pb-16">
           <div className="bg-white border-4 border-black p-6 sm:p-10 shadow-md rounded">
@@ -172,7 +164,7 @@ const AboutPage = () => {
           </div>
         </section>
       </Container>
-      <Footer hideBio />
+      <Footer hideBio hideConnect />
     </>
   );
 };

--- a/src/templates/aboutPage.js
+++ b/src/templates/aboutPage.js
@@ -1,26 +1,174 @@
 import React from "react";
-// import { Link } from "gatsby";
 import MainMenu from "../components/mainMenu";
 import Footer from "../components/footer";
 import Container from "../components/container";
 import Seo from "../components/seo";
 
-// TODO: What are we going to put here?
+// ProfilePage + a Person mainEntity is the schema.org shape recommended for a
+// dedicated bio page — distinct from the bare Person block on the home page,
+// so search engines see one canonical "about" document rather than two
+// competing Person entities.
+const ABOUT_SCHEMA = {
+  "@context": "https://schema.org",
+  "@type": "ProfilePage",
+  mainEntity: {
+    "@type": "Person",
+    name: "Thiago Colen",
+    url: "https://thiagocolen.github.io/about/",
+    jobTitle: "AI Engineer",
+    description:
+      "AI Engineer building production agentic systems (LangGraph, Retrieval-Augmented Generation, Anthropic Claude), with a background in front-end development and web architecture.",
+    knowsAbout: [
+      "Agentic Systems",
+      "LangGraph",
+      "Retrieval-Augmented Generation",
+      "Anthropic Claude",
+      "TypeScript",
+      "AWS",
+      "Terraform",
+      "Front-End Architecture",
+    ],
+    sameAs: [
+      "https://github.com/thiagocolen",
+      "https://www.linkedin.com/in/thiagocolen/",
+      "https://dev.to/thiagocolen",
+    ],
+  },
+};
 
-const AboutPage = ({ pageContext }) => {
+const CONNECT_LINKS = [
+  {
+    label: "Dev.to",
+    href: "https://dev.to/thiagocolen",
+    viewBox: "0 0 512 512",
+    path: "M120.12 208.29c-3.88-2.9-7.77-4.35-11.65-4.35H91.03v104.47h17.45c3.88 0 7.77-1.45 11.65-4.35s5.82-7.25 5.82-13.06v-69.65c-.01-5.8-1.96-10.16-5.83-13.06zM404.1 32H43.9C19.7 32 .06 51.59 0 75.8v360.4C.06 460.41 19.7 480 43.9 480h360.2c24.21 0 43.84-19.59 43.9-43.8V75.8c-.06-24.21-19.7-43.8-43.9-43.8zM154.2 291.19c0 18.81-11.61 47.31-48.36 47.25h-46.4V172.98h47.38c35.44 0 47.36 28.46 47.37 47.28zm100.68-88.66H201.6v38.42h32.57v29.57H201.6v38.41h53.29v29.57h-62.18c-11.16.29-20.44-8.53-20.72-19.69V193.7c-.27-11.15 8.56-20.41 19.71-20.69h63.19zm103.64 115.29c-13.2 30.75-36.85 24.63-47.44 0l-38.53-144.8h32.57l29.71 113.72 29.57-113.72h32.58z",
+  },
+  {
+    label: "GitHub",
+    href: "https://github.com/thiagocolen",
+    viewBox: "0 0 496 512",
+    path: "M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3.3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5.3-6.2 2.3zm44.2-1.7c-2.9.7-4.9 2.6-4.6 4.9.3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.3-14.3-112.3-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3.7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3.3 2.9 2.3 3.9 1.6 1 3.6.7 4.3-.7.7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3.7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3.7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z",
+  },
+  {
+    label: "LinkedIn",
+    href: "https://www.linkedin.com/in/thiagocolen/",
+    viewBox: "0 0 448 512",
+    path: "M100.28 448H7.4V148.9h92.88zM53.79 108.1C24.09 108.1 0 83.5 0 53.8a53.79 53.79 0 0 1 107.58 0c0 29.7-24.1 54.3-53.79 54.3zM447.9 448h-92.68V302.4c0-34.7-.7-79.2-48.29-79.2-48.29 0-55.69 37.7-55.69 76.7V448h-92.78V148.9h89.08v40.8h1.3c12.4-23.5 42.69-48.3 87.88-48.3 94 0 111.28 61.9 111.28 142.3V448z",
+  },
+  {
+    label: "Email",
+    href: "mailto:thiago.souzacolen@gmail.com",
+    viewBox: "0 0 24 24",
+    path: "M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z",
+  },
+];
+
+const KNOWS_ABOUT = [
+  "Agentic Systems",
+  "LangGraph",
+  "Retrieval-Augmented Generation",
+  "Anthropic Claude",
+  "TypeScript",
+  "AWS",
+  "Terraform",
+  "Front-End Architecture",
+];
+
+const AboutPage = () => {
   return (
     <>
-      {/* noindex until this page has actual content — an empty page in the
-          index is a quality signal working against the rest of the site. */}
       <Seo
         title="About"
-        description="About Thiago Colen."
+        description="Thiago Colen — AI Engineer building production agentic systems (LangGraph, Retrieval-Augmented Generation, Anthropic Claude), with a background in front-end development and cloud infrastructure."
         path="/about/"
-        noindex
+        schema={ABOUT_SCHEMA}
       />
       <MainMenu activePage="about" />
       <Container>
-        <h1 className="text-red-500 text-3xl font-semibold mb-6">About</h1>
+        <section className="max-w-3xl mx-auto w-full pt-4 pb-16">
+          <div className="bg-white border-4 border-black p-6 sm:p-10 shadow-md rounded">
+            <h1 className="font-head text-2xl sm:text-3xl font-extrabold mb-2">
+              Thiago Colen
+            </h1>
+            <p className="font-domine text-xs sm:text-sm uppercase tracking-wide font-bold text-black text-opacity-70 mb-6">
+              AI Engineering, Agentic Systems (LangGraph, RAG) &amp; Anthropic Claude ·
+              Software &amp; Front-End Architecture
+            </p>
+
+            <div className="font-sans text-sm sm:text-base leading-relaxed text-black space-y-4">
+              <p>
+                Building a production-grade agentic system on AWS, combining
+                LangChain-based Deep Agents with retrieval-augmented generation
+                to ground AI-driven applications in reliable, context-aware
+                reasoning. Brings a background spanning front-end architecture
+                and cloud infrastructure, with recent focus on designing and
+                deploying scalable AI systems that integrate large language
+                models into real-world products.
+              </p>
+              <p>
+                Experienced in leading technical initiatives across the full
+                stack, from cloud-native infrastructure to user-facing
+                frameworks, with a current emphasis on agentic systems, prompt
+                engineering, and applied AI architecture on AWS.
+              </p>
+              <p>
+                Outside of the day job, writes essays on algorithms, system
+                design, and cellular automata, and ships small build-in-public
+                tools under the{" "}
+                <a
+                  href="https://dev.to/thiagocolen"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline decoration-2 underline-offset-2 hover:text-primary-hover"
+                >
+                  Let&apos;s Fail Project
+                </a>{" "}
+                banner — small, cheap, frequent experiments over big bets.
+              </p>
+            </div>
+
+            {/* Skills / knowsAbout, mirrored from the Person schema so the
+                visible page and the structured data tell the same story. */}
+            <div className="mt-8">
+              <h2 className="font-head text-xs uppercase tracking-widest font-extrabold mb-3">
+                Works With
+              </h2>
+              <ul className="flex flex-wrap gap-2">
+                {KNOWS_ABOUT.map((skill) => (
+                  <li
+                    key={skill}
+                    className="font-domine text-xs sm:text-sm font-bold border-2 border-black bg-accent px-3 py-1 rounded shadow-xs"
+                  >
+                    {skill}
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            {/* Connect */}
+            <div className="mt-10">
+              <h2 className="font-head text-xs uppercase tracking-widest font-extrabold mb-3">
+                Connect
+              </h2>
+              <div className="flex flex-wrap gap-4">
+                {CONNECT_LINKS.map((link) => (
+                  <a
+                    key={link.label}
+                    href={link.href}
+                    target={link.href.startsWith("mailto:") ? undefined : "_blank"}
+                    rel={link.href.startsWith("mailto:") ? undefined : "noopener noreferrer"}
+                    className="w-12 h-12 flex items-center justify-center border-3 border-black bg-white hover:bg-black hover:text-white text-black rounded shadow-xs hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-none transition-all"
+                    aria-label={link.label}
+                  >
+                    <svg className="w-6 h-6 fill-current" viewBox={link.viewBox}>
+                      <path d={link.path} />
+                    </svg>
+                  </a>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
       </Container>
       <Footer />
     </>

--- a/src/templates/aboutPage.js
+++ b/src/templates/aboutPage.js
@@ -91,15 +91,6 @@ const AboutPage = () => {
 
             <div className="font-sans text-sm sm:text-base leading-relaxed text-black space-y-4">
               <p>
-                Building a production-grade agentic system on AWS, combining
-                LangChain-based Deep Agents with retrieval-augmented generation
-                to ground AI-driven applications in reliable, context-aware
-                reasoning. Brings a background spanning front-end architecture
-                and cloud infrastructure, with recent focus on designing and
-                deploying scalable AI systems that integrate large language
-                models into real-world products.
-              </p>
-              <p>
                 Experienced in leading technical initiatives across the full
                 stack, from cloud-native infrastructure to user-facing
                 frameworks, with a current emphasis on agentic systems, prompt

--- a/src/templates/aboutPage.js
+++ b/src/templates/aboutPage.js
@@ -91,6 +91,15 @@ const AboutPage = () => {
 
             <div className="font-sans text-sm sm:text-base leading-relaxed text-black space-y-4">
               <p>
+                Building a production-grade agentic system on AWS, combining
+                LangChain-based Deep Agents with retrieval-augmented generation
+                to ground AI-driven applications in reliable, context-aware
+                reasoning. Brings a background spanning front-end architecture
+                and cloud infrastructure, with recent focus on designing and
+                deploying scalable AI systems that integrate large language
+                models into real-world products.
+              </p>
+              <p>
                 Experienced in leading technical initiatives across the full
                 stack, from cloud-native infrastructure to user-facing
                 frameworks, with a current emphasis on agentic systems, prompt

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -3,9 +3,9 @@ export const songsSnippets = [
   "That's me on the back of the bus. That's me in the cell. That's me inside your head.",
   "I said I bet that you look good on the dance floor. Dancing to electro-pop like a robot from 1984.",
   "A modern day warrior. Mean, mean stride. Today's Tom Sawyer. Mean, mean pride.",
-  "As the world goes. The strong do what they can. And the weak suffer what they must. Shallow be thy graves.",
   "All I ever wanted. All I ever needed is here in my arms. Words are very unnecessary. They can only do harm.",
   "And I'm watchin' and I'm waitin' Hopin' for the best, Even think I'll go to prayin' Every time I hear 'em sayin' That there's no way to delay, That trouble comin' every day",
   "My name is Mud, Not to be confused with Bill or Jack or Pete or Dennis, My name is Mud and it's always been",
-  "Watch out where the huskies go, and don't you eat that yellow snow"
+  "Watch out where the huskies go, and don't you eat that yellow snow",
+  "Fear leads to panic, panic leads to pain, Pain leads to anger, anger leads to hate, Hey, ey, ey, ey, Danny Nedelko"
 ];


### PR DESCRIPTION
## Summary
- `/about/` was an empty, noindexed stub (superseded by the footer bio in #73). This gives it real, indexable content: a bio section, a "Works With" skills list, and connect links — content mirrored from the existing footer bio and homepage `Person` schema so the story stays consistent across the site.
- Adds a `ProfilePage`/`Person` JSON-LD block to the page (distinct from the bare `Person` type on the home page, so search engines see one canonical "about" document rather than two competing entities).
- Removes `/about/` from the sitemap `excludes` in `gatsby-config.js` now that it has content worth indexing, and drops its `noindex` flag.
- Links the page from the nav (`mainMenu.js`) and adds a "Read the full bio →" link from the footer bio back to `/about/`, for internal linking.

Closes #79

## Test plan
- [x] `npm run build` succeeds
- [x] Built `/about/index.html` has `<title>About — Thiago Colen</title>`, `robots: index, follow, ...` (no noindex), and a `ProfilePage` schema block
- [x] `/about/` appears in the generated sitemap
- [x] Nav "ABOUT" link and footer "Read the full bio" link both point to `/about/` and render on other pages (home, blog)
- [ ] Visual check in a browser (`gatsby develop`) for the brutalist styling on various breakpoints